### PR TITLE
Add a customizable spectrum preprocessing

### DIFF
--- a/depthcharge/data/__init__.py
+++ b/depthcharge/data/__init__.py
@@ -1,4 +1,6 @@
 """The Pytorch Datasets"""
+from . import preprocessing
+
 from .datasets import (
     SpectrumDataset,
     PairedSpectrumDataset,

--- a/depthcharge/data/loaders.py
+++ b/depthcharge/data/loaders.py
@@ -44,6 +44,7 @@ class SpectrumDataModule(LightningDataModule):
         batch_size=128,
         n_peaks=200,
         min_mz=140,
+        preprocessing_fn=None,
         num_workers=None,
         random_state=None,
     ):
@@ -55,6 +56,7 @@ class SpectrumDataModule(LightningDataModule):
         self.batch_size = batch_size
         self.n_peaks = n_peaks
         self.min_mz = min_mz
+        self.preprocessing_fn = preprocessing_fn
         self.num_workers = num_workers
         self.rng = np.random.default_rng(random_state)
         self.train_dataset = None
@@ -112,6 +114,7 @@ class SpectrumDataModule(LightningDataModule):
             index,
             n_peaks=self.n_peaks,
             min_mz=self.min_mz,
+            preprocessing_fn=self.preprocessing_fn,
             random_state=random_state,
         )
 

--- a/depthcharge/data/preprocessing.py
+++ b/depthcharge/data/preprocessing.py
@@ -1,0 +1,76 @@
+"""Preprocessing functions for mass spectra.
+
+These functions can be used with any depthcharge dataset or
+data module.
+
+
+"""
+from typing import Tuple
+
+import torch
+
+
+def sqrt_and_norm(
+    mz_array: torch.Tensor,
+    int_array: torch.Tensor,
+    precursor_mz: float,
+    precursor_charge: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Square root the intensities and scale to unit norm.
+
+    Parameters
+    ----------
+    mz_array : torch.Tensor of shape (n_peaks,)
+        The m/z values of the peaks in the spectrum.
+    int_array : torch.Tensor of shape (n_peaks,)
+        The intensity values of the peaks in the spectrum.
+    precursor_mz : float
+        The precursor m/z.
+    precursor_charge : int
+        The precursor charge.
+
+    Returns
+    -------
+    mz_array : torch.Tensor of shape (n_peaks,)
+        The m/z values of the peaks in the spectrum.
+    int_array : torch.Tensor of shape (n_peaks,)
+        The intensity values of the peaks in the spectrum.
+    """
+    print(int_array)
+    int_array = torch.sqrt(int_array)
+    int_array /= torch.linalg.norm(int_array)
+    return mz_array, int_array
+
+
+def remove_precursor_peak(
+    mz_array: torch.Tensor,
+    int_array: torch.Tensor,
+    precursor_mz: float,
+    tol: float = 1.5,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+
+    """Square root the intensities and scale to unit norm.
+
+    Parameters
+    ----------
+    mz_array : torch.Tensor of shape (n_peaks,)
+        The m/z values of the peaks in the spectrum.
+    int_array : torch.Tensor of shape (n_peaks,)
+        The intensity values of the peaks in the spectrum.
+    precursor_mz : float
+        The precursor m/z.
+    precursor_charge : int
+        The precursor charge.
+    tol : float, optional
+        The tolerance to remove the precursor peak in m/z.
+
+    Returns
+    -------
+    mz_array : torch.Tensor of shape (n_peaks,)
+        The m/z values of the peaks in the spectrum.
+    int_array : torch.Tensor of shape (n_peaks,)
+        The intensity values of the peaks in the spectrum.
+    """
+    bounds = (precursor_mz - tol, precursor_mz + tol)
+    outside = (mz_array >= bounds[0]) | (mz_array <= bounds[1])
+    return mz_array[outside], int_array[outside]


### PR DESCRIPTION
The `SpectrumDataset` and `AnnotatedSpectrumDataset` classes now take a `preprocessing_fn` argument that cam specify one or more functions used to process a spectrum.