### PR TITLE
Parse mzXML files

### DIFF
--- a/depthcharge/data/hdf5.py
+++ b/depthcharge/data/hdf5.py
@@ -3,11 +3,10 @@ import logging
 from pathlib import Path
 
 import h5py
-import torch
 import numpy as np
 
 from .. import utils
-from .parsers import MzmlParser, MgfParser
+from .parsers import MzmlParser, MzxmlParser, MgfParser
 
 LOGGER = logging.getLogger(__name__)
 
@@ -120,10 +119,13 @@ class SpectrumIndex:
         if ms_data_file.suffix.lower() == ".mzml":
             return MzmlParser(ms_data_file, ms_level=self.ms_level)
 
+        if ms_data_file.suffix.lower() == ".mzxml":
+            return MzxmlParser(ms_data_file, ms_level=self.ms_level)
+
         if ms_data_file.suffix.lower() == ".mgf":
             return MgfParser(ms_data_file, ms_level=self.ms_level)
 
-        raise ValueError(f"Only mzML and MGF files are supported.")
+        raise ValueError("Only mzML, mzXML, and MGF files are supported.")
 
     def _assemble_metadata(self, parser):
         """Assemble the metadata.

--- a/depthcharge/data/hdf5.py
+++ b/depthcharge/data/hdf5.py
@@ -208,7 +208,7 @@ class SpectrumIndex:
                     data=parser.annotations,
                     dtype=h5py.string_dtype(),
                 )
-            except KeyError:
+            except (KeyError, AttributeError):
                 pass
 
             self._file_map[str(ms_data_file)] = group_index

--- a/depthcharge/data/parsers.py
+++ b/depthcharge/data/parsers.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 from tqdm.auto import tqdm
 from pyteomics.mzml import MzML
+from pyteomics.mzxml import MzXML
 from pyteomics.mgf import MGF
 
 
@@ -108,6 +109,48 @@ class MzmlParser(BaseParser):
             )
             self.precursor_mz.append(data["selected ion m/z"])
             self.precursor_charge.append(data.get("charge state", 0))
+        else:
+            self.precursor_mz.append(None)
+            self.precursor_charge.append(None)
+
+        self.mz_arrays.append(spectrum["m/z array"])
+        self.intensity_arrays.append(spectrum["intensity array"])
+
+
+class MzxmlParser(BaseParser):
+    """Parse mass spectra from an mzXML file.
+
+    Parameters
+    ----------
+    ms_data_file : str or Path
+        The mzXML file to parse.
+    ms_level : int
+        The MS level of the spectra to parse.
+    """
+
+    def __init__(self, ms_data_file, ms_level=2):
+        """Initialize the MzxmlParser."""
+        super().__init__(ms_data_file, ms_level=ms_level)
+
+    def open(self):
+        """Open the mzXML file for reading"""
+        return MzXML(str(self.path))
+
+    def parse_spectrum(self, spectrum):
+        """Parse a single spectrum.
+
+        Parameters
+        ----------
+        spectrum : dict
+            The dictionary defining the spectrum in mzXML format.
+        """
+        if spectrum["msLevel"] != self.ms_level:
+            return
+
+        if self.ms_level > 1:
+            data = spectrum["precursorMz"][0]
+            self.precursor_mz.append(data["precursorMz"])
+            self.precursor_charge.append(data.get("precursorCharge", 0))
         else:
             self.precursor_mz.append(None)
             self.precursor_charge.append(None)

--- a/depthcharge/data/parsers.py
+++ b/depthcharge/data/parsers.py
@@ -117,12 +117,12 @@ class MzmlParser(BaseParser):
 
 
 class MgfParser(BaseParser):
-    """Parse mass spectra from an mzML file.
+    """Parse mass spectra from an MGF file.
 
     Parameters
     ----------
     ms_data_file : str or Path
-        The mzML file to parse.
+        The MGF file to parse.
     ms_level : int
         The MS level of the spectra to parse.
     annotations : bool
@@ -130,12 +130,12 @@ class MgfParser(BaseParser):
     """
 
     def __init__(self, ms_data_file, ms_level=2, annotations=False):
-        """Initialize the MzmlParser."""
+        """Initialize the MgfParser."""
         super().__init__(ms_data_file, ms_level=ms_level)
         self.annotations = [] if annotations else None
 
     def open(self):
-        """Open the mzML file for reading"""
+        """Open the MGF file for reading"""
         return MGF(str(self.path))
 
     def parse_spectrum(self, spectrum):
@@ -144,7 +144,7 @@ class MgfParser(BaseParser):
         Parameters
         ----------
         spectrum : dict
-            The dictionary defining the spectrum in mzML format.
+            The dictionary defining the spectrum in MGF format.
         """
         if self.ms_level > 1:
             self.precursor_mz.append(spectrum["params"]["pepmass"][0])


### PR DESCRIPTION
Read (unannotated) spectra from an mzXML file. Plus a small fix to not crash for unannotated spectra from both mzXML and mzML files.