### PR TITLE
Add option to dekonize peptide into AA list

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,11 +6,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install flake8
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: tests
 
 on:
@@ -8,8 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  schedule:
-  - cron: "0 0 1 1/1 *" # Run monthly
 
 jobs:
   build:
@@ -19,11 +14,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |
@@ -36,6 +31,6 @@ jobs:
         pytest --cov=depthcharge tests/
 
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,4 +33,5 @@ jobs:
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2022-11-15
+### Changed
+- The `detokenize()` method now returns a list instead of a string.
+
 ## [0.0.1] - 2022-09-29
 ### Added
 - This if the first release! All changes from this point forward will be

--- a/depthcharge/components/transformers.py
+++ b/depthcharge/components/transformers.py
@@ -185,11 +185,17 @@ class _PeptideTransformer(torch.nn.Module):
         return tokens
 
     def detokenize(self, tokens):
-        """Transform tokens back into a peptide sequence
+        """Transform tokens back into a peptide sequence.
 
         Parameters
         ----------
-        tokens : torch.Tensor of shape (n_amino_acids)
+        tokens : torch.Tensor of shape (n_amino_acids,)
+            The token for each amino acid in the peptide sequence.
+
+        Returns
+        -------
+        list of str
+            The amino acids in the peptide sequence.
         """
         sequence = [self._idx2aa.get(i.item(), "") for i in tokens]
         if "$" in sequence:

--- a/depthcharge/components/transformers.py
+++ b/depthcharge/components/transformers.py
@@ -184,12 +184,15 @@ class _PeptideTransformer(torch.nn.Module):
         tokens = torch.tensor(tokens, device=self.device)
         return tokens
 
-    def detokenize(self, tokens):
+    def detokenize(self, tokens, pep_as_str=True):
         """Transform tokens back into a peptide sequence
 
         Parameters
         ----------
         tokens : torch.Tensor of shape (n_amino_acids)
+        pep_as_str: bool, optional
+            Return peptide sequence in str format by default.
+            If "False", returns a list of amino acids.
         """
         sequence = [self._idx2aa.get(i.item(), "") for i in tokens]
         if "$" in sequence:
@@ -199,7 +202,7 @@ class _PeptideTransformer(torch.nn.Module):
         if self.reverse:
             sequence = list(reversed(sequence))
 
-        return "".join(sequence)
+        return "".join(sequence) if pep_as_str else sequence
 
     @property
     def vocab_size(self):

--- a/depthcharge/components/transformers.py
+++ b/depthcharge/components/transformers.py
@@ -184,15 +184,12 @@ class _PeptideTransformer(torch.nn.Module):
         tokens = torch.tensor(tokens, device=self.device)
         return tokens
 
-    def detokenize(self, tokens, pep_as_str=True):
+    def detokenize(self, tokens):
         """Transform tokens back into a peptide sequence
 
         Parameters
         ----------
         tokens : torch.Tensor of shape (n_amino_acids)
-        pep_as_str: bool, optional
-            Return peptide sequence in str format by default.
-            If "False", returns a list of amino acids.
         """
         sequence = [self._idx2aa.get(i.item(), "") for i in tokens]
         if "$" in sequence:
@@ -202,7 +199,7 @@ class _PeptideTransformer(torch.nn.Module):
         if self.reverse:
             sequence = list(reversed(sequence))
 
-        return "".join(sequence) if pep_as_str else sequence
+        return sequence
 
     @property
     def vocab_size(self):

--- a/tests/unit_tests/test_denovo.py
+++ b/tests/unit_tests/test_denovo.py
@@ -26,4 +26,4 @@ def test_denovo_model(tmp_path, mgf_small):
 
     # Predict
     pred = trainer.predict(model, loaders.train_dataloader())
-    assert pred[0][0][0][0] == "$LESLLEK"
+    assert "".join(pred[0][0][0][0]) == "$LESLLEK"


### PR DESCRIPTION
Added option for `detokenize` to return peptide sequence as a list of amino acids rather than only in the string format. This was needed in the context of Casanovo for cases where multiple N-terminal modifications are predicted back to back (e.g. -17.027+42.011) and the downstream regex logic fails to differentiate these PTMs. Refer to below discussion for more details:
https://github.com/Noble-Lab/casanovo/pull/87#discussion_r1023220461