### PR TITLE
Fix calculation of m/z for charged peptides.

### DIFF
--- a/depthcharge/masses.py
+++ b/depthcharge/masses.py
@@ -94,6 +94,6 @@ class PeptideMass:
 
         calc_mass = sum([self.masses[aa] for aa in seq]) + self.h2o
         if charge is not None:
-            calc_mass = (calc_mass / charge) + self.proton
+            calc_mass = (calc_mass + charge * self.proton) / charge
 
         return calc_mass


### PR DESCRIPTION
Not sure if I'm misreading, but I think I found a bug in the calculation of m/z of charged peptides.