### PR TITLE
Create target mask as bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Change target mask from float to boolean.
 - Log the number spectra that are skipped due to an invalid precursor charge.
 
 ## [0.2.0] - 2023-03-06

--- a/depthcharge/components/transformers.py
+++ b/depthcharge/components/transformers.py
@@ -449,22 +449,11 @@ class PeptideDecoder(_PeptideTransformer):
 
 
 def generate_tgt_mask(sz):
-    """Generate a square mask for the sequence. The masked positions
-    are filled with float('-inf'). Unmasked positions are filled with
-    float(0.0).
-
-    This function is a slight modification of the version in the PyTorch
-    repository.
+    """Generate a square mask for the sequence.
 
     Parameters
     ----------
     sz : int
         The length of the target sequence.
     """
-    mask = (torch.triu(torch.ones(sz, sz)) == 1).transpose(0, 1)
-    mask = (
-        mask.float()
-        .masked_fill(mask == 0, float("-inf"))
-        .masked_fill(mask == 1, float(0.0))
-    )
-    return mask
+    return ~torch.triu(torch.ones(sz, sz, dtype=torch.bool)).transpose(0, 1)


### PR DESCRIPTION
Avoids "UserWarning: Support for mismatched key_padding_mask and attn_mask is deprecated. Use same type for both instead." from [Casanovo#174](https://github.com/Noble-Lab/casanovo/issues/174).

@wfondrie I don't understand the motivation of creating the mask with `0` and `-inf` previously, so please carefully double-check the change. I also can't find a version of `generate_tgt_mask` in the PyTorch repository.