### PR TITLE
Preprocess spectra before adding to index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Change target mask from float to boolean.
 - Log the number spectra that are skipped due to an invalid precursor charge.
+- Preprocess spectra before adding them to the index.
 
 ## [0.2.0] - 2023-03-06
 ### Breaking Changes

--- a/depthcharge/data/hdf5.py
+++ b/depthcharge/data/hdf5.py
@@ -42,6 +42,11 @@ class SpectrumIndex:
     path : Path
     ms_level : int
     valid_charge : Optional[Iterable[int]]
+    min_mz : Optional[float]
+    max_mz : Optional[float]
+    min_intensity : Optional[float]
+    max_n_peaks : Optional[int]
+    remove_precursor_tol : Optional[float]
     annotated : bool
     overwrite : bool
     n_spectra : int
@@ -54,6 +59,11 @@ class SpectrumIndex:
         ms_data_files=None,
         ms_level=2,
         valid_charge=None,
+        min_mz=None,
+        max_mz=None,
+        min_intensity=None,
+        max_n_peaks=None,
+        remove_precursor_tol=None,
         annotated=False,
         overwrite=False,
     ):
@@ -66,6 +76,11 @@ class SpectrumIndex:
         self._path = index_path
         self._ms_level = utils.check_positive_int(ms_level, "ms_level")
         self._valid_charge = valid_charge
+        self._min_mz = min_mz
+        self._max_mz = max_mz
+        self._min_intensity = min_intensity
+        self._max_n_peaks = max_n_peaks
+        self._remove_precursor_tol = remove_precursor_tol
         self._annotated = bool(annotated)
         self._overwrite = bool(overwrite)
         self._handle = None
@@ -133,7 +148,15 @@ class SpectrumIndex:
         MzmlParser, MzxmlParser, or MgfParser
             The appropriate parser for the file.
         """
-        kw_args = dict(ms_level=self.ms_level, valid_charge=self.valid_charge)
+        kw_args = dict(
+            ms_level=self.ms_level,
+            valid_charge=self.valid_charge,
+            min_mz=self.min_mz,
+            max_mz=self.max_mz,
+            min_intensity=self.min_intensity,
+            max_n_peaks=self.max_n_peaks,
+            remove_precursor_tol=self.remove_precursor_tol,
+        )
 
         if ms_data_file.suffix.lower() == ".mzml":
             return MzmlParser(ms_data_file, **kw_args)
@@ -179,9 +202,9 @@ class SpectrumIndex:
         Parameters
         ----------
         ms_data_file : str or Path
-            The mass spectrometry data file to add. It must be in an mzML or
-            MGF file format and use an ``.mzML``, ``.mzXML``, or ``.mgf`` file
-            extension.
+            The mass spectrometry data file to add. It must be in an mzML,
+            mzXML, or MGF file format and use an ``.mzML``, ``.mzXML``, or
+            ``.mgf`` file extension.
         """
         ms_data_file = Path(ms_data_file)
         if str(ms_data_file) in self._file_map:
@@ -372,6 +395,32 @@ class SpectrumIndex:
         return self._valid_charge
 
     @property
+    def min_mz(self):
+        """Valid minimum m/z for peaks in the spectra."""
+        return self._min_mz
+
+    @property
+    def max_mz(self):
+        """Valid maximum m/z for peaks in the spectra."""
+        return self._max_mz
+
+    @property
+    def min_intensity(self):
+        """Valid relative minimum intensity for peaks in the spectra."""
+        return self._min_intensity
+
+    @property
+    def max_n_peaks(self):
+        """The maximum number of most intense peaks retained in each
+        spectrum."""
+        return self._max_n_peaks
+
+    @property
+    def remove_precursor_tol(self):
+        """M/z tolerance to remove peaks around the precursor m/z."""
+        return self._remove_precursor_tol
+
+    @property
     def annotated(self):
         """Whether or not the index contains spectrum annotations."""
         return self._annotated
@@ -440,6 +489,11 @@ class AnnotatedSpectrumIndex(SpectrumIndex):
         ms_data_files=None,
         ms_level=2,
         valid_charge=None,
+        min_mz=None,
+        max_mz=None,
+        min_intensity=None,
+        max_n_peaks=None,
+        remove_precursor_tol=None,
         overwrite=False,
     ):
         """Initialize an AnnotatedSpectrumIndex"""
@@ -448,6 +502,11 @@ class AnnotatedSpectrumIndex(SpectrumIndex):
             ms_data_files=ms_data_files,
             ms_level=ms_level,
             valid_charge=valid_charge,
+            min_mz=min_mz,
+            max_mz=max_mz,
+            min_intensity=min_intensity,
+            max_n_peaks=max_n_peaks,
+            remove_precursor_tol=remove_precursor_tol,
             annotated=True,
             overwrite=overwrite,
         )
@@ -458,6 +517,12 @@ class AnnotatedSpectrumIndex(SpectrumIndex):
             return MgfParser(
                 ms_data_file,
                 ms_level=self.ms_level,
+                valid_charge=self.valid_charge,
+                min_mz=self.min_mz,
+                max_mz=self.max_mz,
+                min_intensity=self.min_intensity,
+                max_n_peaks=self.max_n_peaks,
+                remove_precursor_tol=self.remove_precursor_tol,
                 annotations=True,
             )
 

--- a/depthcharge/data/parsers.py
+++ b/depthcharge/data/parsers.py
@@ -1,13 +1,15 @@
 """Mass spectrometry data parsers"""
 import logging
-from pathlib import Path
 from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Tuple
 
 import numpy as np
-from tqdm.auto import tqdm
+import spectrum_utils.spectrum as sus
+from pyteomics.mgf import MGF
 from pyteomics.mzml import MzML
 from pyteomics.mzxml import MzXML
-from pyteomics.mgf import MGF
+from tqdm.auto import tqdm
 
 
 LOGGER = logging.getLogger(__name__)
@@ -25,6 +27,17 @@ class BaseParser(ABC):
     valid_charge : Iterable[int], optional
         Only consider spectra with the specified precursor charges. If `None`,
         any precursor charge is accepted.
+    min_mz : Optional[float]
+        Remove spectrum peaks below the given minimum m/z.
+    max_mz : Optional[float]
+        Remove spectrum peaks above the given maximum m/z.
+    min_intensity : Optional[float]
+        Remove spectrum peaks below the given relative minimum intensity.
+    max_n_peaks : Optional[int]
+        Only keep the specified number of most intense peaks in each spectrum.
+    remove_precursor_tol : Optional[float]
+        Remove spectrum peaks in the given m/z tolerance around the precursor
+        m/z.
     id_type : str, optional
         The Hupo-PSI prefix for the spectrum identifier.
     """
@@ -34,12 +47,22 @@ class BaseParser(ABC):
         ms_data_file,
         ms_level,
         valid_charge=None,
+        min_mz=None,
+        max_mz=None,
+        min_intensity=None,
+        max_n_peaks=None,
+        remove_precursor_tol=None,
         id_type="scan",
     ):
         """Initialize the BaseParser"""
         self.path = Path(ms_data_file)
         self.ms_level = ms_level
         self.valid_charge = None if valid_charge is None else set(valid_charge)
+        self.min_mz = min_mz
+        self.max_mz = max_mz
+        self.min_intensity = 0.0 if min_intensity is None else min_intensity
+        self.max_n_peaks = max_n_peaks
+        self.remove_precursor_tol = remove_precursor_tol
         self.id_type = id_type
         self.offset = None
         self.precursor_mz = []
@@ -54,42 +77,51 @@ class BaseParser(ABC):
         pass
 
     @abstractmethod
-    def parse_spectrum(self, spectrum):
-        """Parse a single spectrum
+    def parse_spectrum(self, spectrum) -> sus.MsmsSpectrum:
+        """Parse a single spectrum.
 
         Parameters
         ----------
         spectrum : dict
             The dictionary defining the spectrum in a given format.
+
+        Returns
+        -------
+        sus.MsmsSpectrum
+            The parsed spectrum as an MsmsSpectrum object.
+
+        Raises
+        ------
+        ValueError
+            If the spectrum properties are invalid (unsupported MS level or
+            precursor charge).
         """
         pass
 
     def read(self):
-        """Read the ms data file.
-
-        Returns
-        -------
-        Self
-        """
+        """Read the ms data file."""
         n_skipped = 0
         with self.open() as spectra:
             for spectrum in tqdm(spectra, desc=str(self.path), unit="spectra"):
                 try:
-                    self.parse_spectrum(spectrum)
+                    spectrum = self.parse_spectrum(spectrum)
+                    mz_array, int_array = self._process_peaks(spectrum)
+
+                    self.scan_id.append(_parse_scan_id(spectrum.identifier))
+                    self.precursor_mz.append(spectrum.precursor_mz)
+                    self.precursor_charge.append(spectrum.precursor_charge)
+                    self.mz_arrays.append(mz_array)
+                    self.intensity_arrays.append(int_array)
                 except (IndexError, KeyError, ValueError):
                     n_skipped += 1
 
         if n_skipped:
             LOGGER.warning(
-                "Skipped %d spectra with invalid precursor info", n_skipped
+                "Skipped %d spectra with invalid properties", n_skipped
             )
 
         self.precursor_mz = np.array(self.precursor_mz, dtype=np.float64)
-        self.precursor_charge = np.array(
-            self.precursor_charge,
-            dtype=np.uint8,
-        )
-
+        self.precursor_charge = np.array(self.precursor_charge, dtype=np.uint8)
         self.scan_id = np.array(self.scan_id)
 
         # Build the index
@@ -99,7 +131,46 @@ class BaseParser(ABC):
         self.intensity_arrays = np.concatenate(self.intensity_arrays).astype(
             np.float32
         )
-        return self
+
+    def _process_peaks(
+        self, spectrum: sus.MsmsSpectrum
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Preprocess the spectrum by removing noise peaks and scaling the peak
+        intensities.
+
+        Parameters
+        ----------
+        spectrum: sus.MsmsSpectrum
+            The spectrum to be preprocessed.
+
+        Returns
+        -------
+        Tuple[np.ndarray, np.ndarray]
+        mz_array:np.ndarray
+            The spectrum peak m/z values after preprocessing.
+        int_array:np.ndarray
+            The spectrum peak intensity values after preprocessing.
+
+        Raises
+        ------
+        ValueError
+            If no peaks are remaining after preprocessing.
+        TODO: Do we want to configure a minimum number of peaks for a spectrum to be valid?
+        """
+        spectrum.set_mz_range(self.min_mz, self.max_mz)
+        if len(spectrum.mz) == 0:
+            raise ValueError
+        if self.remove_precursor_tol is not None:
+            spectrum.remove_precursor_peak(self.remove_precursor_tol, "Da")
+            if len(spectrum.mz) == 0:
+                raise ValueError
+        spectrum.filter_intensity(self.min_intensity, self.max_n_peaks)
+        if len(spectrum.mz) == 0:
+            raise ValueError
+        spectrum.scale_intensity("root", 1)
+        intensities = spectrum.intensity / np.linalg.norm(spectrum.intensity)
+        return spectrum.mz, intensities
 
     @property
     def n_spectra(self):
@@ -124,30 +195,67 @@ class MzmlParser(BaseParser):
     valid_charge : Iterable[int], optional
         Only consider spectra with the specified precursor charges. If `None`,
         any precursor charge is accepted.
+    min_mz : Optional[float]
+        Remove spectrum peaks below the given minimum m/z.
+    max_mz : Optional[float]
+        Remove spectrum peaks above the given maximum m/z.
+    min_intensity : Optional[float]
+        Remove spectrum peaks below the given relative minimum intensity.
+    max_n_peaks : Optional[int]
+        Only keep the specified number of most intense peaks in each spectrum.
+    remove_precursor_tol : Optional[float]
+        Remove spectrum peaks in the given m/z tolerance around the precursor
+        m/z.
     """
 
-    def __init__(self, ms_data_file, ms_level=2, valid_charge=None):
+    def __init__(
+        self,
+        ms_data_file,
+        ms_level=2,
+        valid_charge=None,
+        min_mz=None,
+        max_mz=None,
+        min_intensity=None,
+        max_n_peaks=None,
+        remove_precursor_tol=None,
+    ):
         """Initialize the MzmlParser."""
         super().__init__(
             ms_data_file,
             ms_level=ms_level,
             valid_charge=valid_charge,
+            min_mz=min_mz,
+            max_mz=max_mz,
+            min_intensity=min_intensity,
+            max_n_peaks=max_n_peaks,
+            remove_precursor_tol=remove_precursor_tol,
         )
 
     def open(self):
         """Open the mzML file for reading"""
         return MzML(str(self.path))
 
-    def parse_spectrum(self, spectrum):
+    def parse_spectrum(self, spectrum) -> sus.MsmsSpectrum:
         """Parse a single spectrum.
 
         Parameters
         ----------
         spectrum : dict
             The dictionary defining the spectrum in mzML format.
+
+        Returns
+        -------
+        sus.MsmsSpectrum
+            The parsed spectrum as an MsmsSpectrum object.
+
+        Raises
+        ------
+        ValueError
+            If the spectrum properties are invalid (unsupported MS level or
+            precursor charge).
         """
         if spectrum["ms level"] != self.ms_level:
-            return
+            raise ValueError("Unsupported MS level")
 
         if self.ms_level > 1:
             precursor = spectrum["precursorList"]["precursor"][0]
@@ -162,14 +270,19 @@ class MzmlParser(BaseParser):
         else:
             precursor_mz, precursor_charge = None, 0
 
-        if self.valid_charge is None or precursor_charge in self.valid_charge:
-            self.mz_arrays.append(spectrum["m/z array"])
-            self.intensity_arrays.append(spectrum["intensity array"])
-            self.precursor_mz.append(precursor_mz)
-            self.precursor_charge.append(precursor_charge)
-            self.scan_id.append(_parse_scan_id(spectrum["id"]))
-        else:
-            raise ValueError("Invalid precursor charge")
+        if (
+                self.valid_charge is not None
+                and precursor_charge not in self.valid_charge
+        ):
+            raise ValueError("Unsupported precursor charge")
+
+        return sus.MsmsSpectrum(
+            spectrum["id"],
+            precursor_mz,
+            precursor_charge,
+            spectrum["m/z array"],
+            spectrum["intensity array"]
+        )
 
 
 class MzxmlParser(BaseParser):
@@ -184,14 +297,40 @@ class MzxmlParser(BaseParser):
     valid_charge : Iterable[int], optional
         Only consider spectra with the specified precursor charges. If `None`,
         any precursor charge is accepted.
+    min_mz : Optional[float]
+        Remove spectrum peaks below the given minimum m/z.
+    max_mz : Optional[float]
+        Remove spectrum peaks above the given maximum m/z.
+    min_intensity : Optional[float]
+        Remove spectrum peaks below the given relative minimum intensity.
+    max_n_peaks : Optional[int]
+        Only keep the specified number of most intense peaks in each spectrum.
+    remove_precursor_tol : Optional[float]
+        Remove spectrum peaks in the given m/z tolerance around the precursor
+        m/z.
     """
 
-    def __init__(self, ms_data_file, ms_level=2, valid_charge=None):
+    def __init__(
+        self,
+        ms_data_file,
+        ms_level=2,
+        valid_charge=None,
+        min_mz=None,
+        max_mz=None,
+        min_intensity=None,
+        max_n_peaks=None,
+        remove_precursor_tol=None,
+    ):
         """Initialize the MzxmlParser."""
         super().__init__(
             ms_data_file,
             ms_level=ms_level,
             valid_charge=valid_charge,
+            min_mz=min_mz,
+            max_mz=max_mz,
+            min_intensity=min_intensity,
+            max_n_peaks=max_n_peaks,
+            remove_precursor_tol=remove_precursor_tol,
         )
 
     def open(self):
@@ -205,9 +344,20 @@ class MzxmlParser(BaseParser):
         ----------
         spectrum : dict
             The dictionary defining the spectrum in mzXML format.
+
+        Returns
+        -------
+        sus.MsmsSpectrum
+            The parsed spectrum as an MsmsSpectrum object.
+
+        Raises
+        ------
+        ValueError
+            If the spectrum properties are invalid (unsupported MS level or
+            precursor charge).
         """
         if spectrum["msLevel"] != self.ms_level:
-            return
+            raise ValueError("Unsupported MS level")
 
         if self.ms_level > 1:
             precursor = spectrum["precursorMz"][0]
@@ -216,14 +366,19 @@ class MzxmlParser(BaseParser):
         else:
             precursor_mz, precursor_charge = None, 0
 
-        if self.valid_charge is None or precursor_charge in self.valid_charge:
-            self.mz_arrays.append(spectrum["m/z array"])
-            self.intensity_arrays.append(spectrum["intensity array"])
-            self.precursor_mz.append(precursor_mz)
-            self.precursor_charge.append(precursor_charge)
-            self.scan_id.append(_parse_scan_id(spectrum["id"]))
-        else:
-            raise ValueError("Invalid precursor charge")
+        if (
+                self.valid_charge is not None
+                and precursor_charge not in self.valid_charge
+        ):
+            raise ValueError("Unsupported precursor charge")
+
+        return sus.MsmsSpectrum(
+            spectrum["id"],
+            precursor_mz,
+            precursor_charge,
+            spectrum["m/z array"],
+            spectrum["intensity array"]
+        )
 
 
 class MgfParser(BaseParser):
@@ -238,6 +393,17 @@ class MgfParser(BaseParser):
     valid_charge : Iterable[int], optional
         Only consider spectra with the specified precursor charges. If `None`,
         any precursor charge is accepted.
+    min_mz : Optional[float]
+        Remove spectrum peaks below the given minimum m/z.
+    max_mz : Optional[float]
+        Remove spectrum peaks above the given maximum m/z.
+    min_intensity : Optional[float]
+        Remove spectrum peaks below the given relative minimum intensity.
+    max_n_peaks : Optional[int]
+        Only keep the specified number of most intense peaks in each spectrum.
+    remove_precursor_tol : Optional[float]
+        Remove spectrum peaks in the given m/z tolerance around the precursor
+        m/z.
     annotations : bool
         Include peptide annotations.
     """
@@ -247,6 +413,11 @@ class MgfParser(BaseParser):
         ms_data_file,
         ms_level=2,
         valid_charge=None,
+        min_mz=None,
+        max_mz=None,
+        min_intensity=None,
+        max_n_peaks=None,
+        remove_precursor_tol=None,
         annotations=False,
     ):
         """Initialize the MgfParser."""
@@ -254,10 +425,15 @@ class MgfParser(BaseParser):
             ms_data_file,
             ms_level=ms_level,
             valid_charge=valid_charge,
+            min_mz=min_mz,
+            max_mz=max_mz,
+            min_intensity=min_intensity,
+            max_n_peaks=max_n_peaks,
+            remove_precursor_tol=remove_precursor_tol,
             id_type="index",
         )
         self.annotations = [] if annotations else None
-        self._counter = -1
+        self._counter = 0
 
     def open(self):
         """Open the MGF file for reading"""
@@ -271,6 +447,7 @@ class MgfParser(BaseParser):
         spectrum : dict
             The dictionary defining the spectrum in MGF format.
         """
+        spectrum_id = str(self._counter)
         self._counter += 1
 
         if self.ms_level > 1:
@@ -279,17 +456,22 @@ class MgfParser(BaseParser):
         else:
             precursor_mz, precursor_charge = None, 0
 
+        if (
+                self.valid_charge is not None
+                and precursor_charge not in self.valid_charge
+        ):
+            raise ValueError("Unsupported precursor charge")
+
         if self.annotations is not None:
             self.annotations.append(spectrum["params"].get("seq"))
 
-        if self.valid_charge is None or precursor_charge in self.valid_charge:
-            self.mz_arrays.append(spectrum["m/z array"])
-            self.intensity_arrays.append(spectrum["intensity array"])
-            self.precursor_mz.append(precursor_mz)
-            self.precursor_charge.append(precursor_charge)
-            self.scan_id.append(self._counter)
-        else:
-            raise ValueError("Invalid precursor charge")
+        return sus.MsmsSpectrum(
+            spectrum_id,
+            precursor_mz,
+            precursor_charge,
+            spectrum["m/z array"],
+            spectrum["intensity array"]
+        )
 
 
 def _parse_scan_id(scan_str):

--- a/depthcharge/data/parsers.py
+++ b/depthcharge/data/parsers.py
@@ -271,8 +271,8 @@ class MzmlParser(BaseParser):
             precursor_mz, precursor_charge = None, 0
 
         if (
-                self.valid_charge is not None
-                and precursor_charge not in self.valid_charge
+            self.valid_charge is not None
+            and precursor_charge not in self.valid_charge
         ):
             raise ValueError("Unsupported precursor charge")
 
@@ -281,7 +281,7 @@ class MzmlParser(BaseParser):
             precursor_mz,
             precursor_charge,
             spectrum["m/z array"],
-            spectrum["intensity array"]
+            spectrum["intensity array"],
         )
 
 
@@ -367,8 +367,8 @@ class MzxmlParser(BaseParser):
             precursor_mz, precursor_charge = None, 0
 
         if (
-                self.valid_charge is not None
-                and precursor_charge not in self.valid_charge
+            self.valid_charge is not None
+            and precursor_charge not in self.valid_charge
         ):
             raise ValueError("Unsupported precursor charge")
 
@@ -377,7 +377,7 @@ class MzxmlParser(BaseParser):
             precursor_mz,
             precursor_charge,
             spectrum["m/z array"],
-            spectrum["intensity array"]
+            spectrum["intensity array"],
         )
 
 
@@ -457,8 +457,8 @@ class MgfParser(BaseParser):
             precursor_mz, precursor_charge = None, 0
 
         if (
-                self.valid_charge is not None
-                and precursor_charge not in self.valid_charge
+            self.valid_charge is not None
+            and precursor_charge not in self.valid_charge
         ):
             raise ValueError("Unsupported precursor charge")
 
@@ -470,7 +470,7 @@ class MgfParser(BaseParser):
             precursor_mz,
             precursor_charge,
             spectrum["m/z array"],
-            spectrum["intensity array"]
+            spectrum["intensity array"],
         )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,14 +22,15 @@ classifiers =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    torch>=1.11.0
-    pyteomics>=4.4.2
+    einops>=0.4.1
+    h5py>=3.7.0
+    lxml>=4.9.1
+    numba>=0.48.0
     numpy>=1.18.1
     pandas>=1.0.3
-    numba>=0.48.0
-    lxml>=4.9.1
-    h5py>=3.7.0
-    einops>=0.4.1
+    pyteomics>=4.4.2
+    spectrum_utils>=0.4
+    torch>=1.11.0
     tqdm>=4.65.0
 
 [options.extras_require]


### PR DESCRIPTION
I did some coding on my flight to Japan and moved the preprocessing code from Casanovo to depthcharge to fix [Casanovo#56](https://github.com/Noble-Lab/casanovo/issues/56). The upshot is that invalid spectra are now no longer included in the index on the depthcharge side, rather than later being replaced by a dummy spectrum by Casanovo that will get an incorrect prediction.

This needs some unit tests, but I'm unlikely to be able to add those within the next two weeks while I'm in Japan.

One remaining question is whether we also want to introduce a parameter that specifies the minimum number of peaks (after preprocessing) for spectra to be included?

Linked to [Casanovo#181](https://github.com/Noble-Lab/casanovo/pull/181).