### PR TITLE
change tgt_mask to boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.3.1] - 2023-08-18
 ### Added
 - Support for fine-tuning the wavelengths used for encoding floating point numbers like m/z and intensity to the `FloatEncoder` and `PeakEncoder`.
+
+### Fixed
+- The `tgt_mask` in the `PeptideTransformerDecoder` was the incorrect type.
+  Now it is `bool` as it should be.
+  Thanks @justin-a-sanders!
 
 ## [v0.3.0] - 2023-06-06
 ### Added

--- a/depthcharge/transformers/peptides.py
+++ b/depthcharge/transformers/peptides.py
@@ -267,7 +267,7 @@ class PeptideTransformerDecoder(_PeptideTransformer):
         tgt = torch.cat([precursors, tokens], dim=1)
         tgt_key_padding_mask = tgt.sum(axis=2) == 0
         tgt = self.positional_encoder(tgt)
-        tgt_mask = generate_tgt_mask(tgt.shape[1]).type_as(precursors)
+        tgt_mask = generate_tgt_mask(tgt.shape[1])
         preds = self.transformer_decoder(
             tgt=tgt,
             memory=memory,

--- a/depthcharge/transformers/peptides.py
+++ b/depthcharge/transformers/peptides.py
@@ -267,7 +267,7 @@ class PeptideTransformerDecoder(_PeptideTransformer):
         tgt = torch.cat([precursors, tokens], dim=1)
         tgt_key_padding_mask = tgt.sum(axis=2) == 0
         tgt = self.positional_encoder(tgt)
-        tgt_mask = generate_tgt_mask(tgt.shape[1])
+        tgt_mask = generate_tgt_mask(tgt.shape[1]).to(self.device)
         preds = self.transformer_decoder(
             tgt=tgt,
             memory=memory,


### PR DESCRIPTION
Current depthcharge peptide decoder converts tgt_mask from bool to float, allowing tokens to attend to the future during training. From the pytorch Transformer docs:
> If a BoolTensor is provided, positions with True are not allowed to attend while False values will be unchanged. If a FloatTensor is provided, it will be added to the attention weight.

Leaving the mask as type Boolean resolves the issue. 