### PR TITLE
Fixed Lance directory path bug in SpectrumDataset

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,4 +27,4 @@ jobs:
 
       - name: Check formatting with Ruff
         run: |
-          ruff format --check . --output-format=github
+          ruff format --check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,17 +21,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff
 
-      - name: Run black
-        uses: psf/black@stable
-
       - name: Lint with Ruff
         run: |
-          ruff check . --format=github
+          ruff check . --output-format=github
 
-      - name: Check for debugging print statements
+      - name: Check formatting with Ruff
         run: |
-          if grep -rq "print(" depthcharge; then
-              echo "Found the following print statements:"
-              grep -r "print(" deptchcharge
-              exit 1
-          fi
+          ruff format --check . --output-format=github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: check-toml
   - id: check-yaml
@@ -8,12 +8,12 @@ repos:
   - id: trailing-whitespace
   - id: detect-private-key
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.269
+  rev: v0.1.7
   hooks:
+    # Run the linter.
     - id: ruff
-      args: ['--show-fixes']
-- repo: https://github.com/psf/black
-  rev: 23.3.0
-  hooks:
-    - id: black
-      language_version: python3.10
+      types_or: [ python, pyi, jupyter ]
+      args: [ --fix, --show-fixes ]
+    # Run the formatter.
+    - id: ruff-format
+      types_or: [ python, pyi, jupyter ]

--- a/depthcharge/data/spectrum_datasets.py
+++ b/depthcharge/data/spectrum_datasets.py
@@ -461,8 +461,7 @@ def _get_records(
             except (pa.ArrowInvalid, TypeError):
                 spectra = arrow.spectra_to_stream(spectra, **kwargs)
 
-        for batch in spectra:
-            yield batch
+        yield from spectra
 
 
 def _tensorize(obj: Any) -> Any:  # noqa: ANN401

--- a/depthcharge/data/spectrum_datasets.py
+++ b/depthcharge/data/spectrum_datasets.py
@@ -140,8 +140,8 @@ class SpectrumDataset(Dataset, CollateFnMixin):
             path = Path(self._tmpdir.name) / f"{uuid.uuid4()}.lance"
 
         self._path = Path(path)
-        if self._path.suffix != "lance":
-            self._path = path.with_suffix(".lance")
+        if self._path.suffix != ".lance":
+            self._path = self._path.with_suffix(".lance")
 
         # Now parse spectra.
         if spectra is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ find = {namespaces = false}
 [tool.setuptools_scm]
 
 [tool.ruff]
+line-length = 79
+
+[tool.ruff.lint]
 select = ["E", "F", "W", "C", "I", "D", "UP", "N", "ANN", "T20"]
 
 # ANN101 Missing type annotation for `self` in method
@@ -71,34 +74,9 @@ select = ["E", "F", "W", "C", "I", "D", "UP", "N", "ANN", "T20"]
 # ANN102 Missing type annotation for `cls` in classmethod
 # D401 First line of docstring should be in imperative mood
 ignore = ["D213", "ANN101", "D203", "D100", "ANN102", "D401"]
-fix = true
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "*tests/*.py" = ["ANN", "N806"]
 "__init__.py" = ["F401", "D104"]
 "depthcharge/encoders/sinusoidal.py" = ["N803"]
 "depthcharge/feedforward.py" = ["N803"]
-
-[tool.black]
-line-length = 79
-target-version = ['py310']
-include = '\.pyi?$'
-exclude = '''
-
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-  )/
-  | foo.py           # also separately exclude a file named foo.py in
-                     # the root of the project
-)
-'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ find = {namespaces = false}
 
 [tool.ruff]
 line-length = 79
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "C", "I", "D", "UP", "N", "ANN", "T20"]


### PR DESCRIPTION
`.with_suffix(.lance)` was being called on the str path instead of the pathlib object, causing a crash if the "path" arg is given to the `__init__ `of SpectrumDataset

Secondly, the `.suffix` attribute includes the dot, hence the if statement should compare if 
`if self._path.suffix != ".lance"` instead of 
`if self._path.suffix != "lance"`