### PR TITLE
Update Lance backend to use native PyTorch integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Run unit and system tests
       run: |
-        pytest --cov=depthcharge tests/
+        pytest --cov=depthcharge --verbose tests/
 
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We now also have full support for small molecules, with the `MoleculeTokenizer`,
 - The parsing functionality of `SpctrumDataset` and its subclasses have been moved to the `spectra_to_*` functions in the data module.
 - `SpectrumDataset` and its subclasses now return dictionaries of data rather than a tuple of data. This allows us to incorporate arbitrary additional data
 - `SpectrumDataset` and its subclasses are now `lance.torch.data.LanceDataset` subclasses, providing native PyTorch integration.
+- All dataset classes now do not have a `loader()` method.
 
 ### Added
 - Support for small molecules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v1.0.0]
+## [v0.4.0]
 
 We have completely reworked of the data module.
 Depthcharge now uses Apache Arrow-based formats instead of HDF5; spectra are converted either Parquet or streamed with PyArrow, optionally into Lance datasets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-# Changelog for depthcharge
+# Changelog for Depthcharge
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v1.0.0]
 
 We have completely reworked of the data module.
 Depthcharge now uses Apache Arrow-based formats instead of HDF5; spectra are converted either Parquet or streamed with PyArrow, optionally into Lance datasets.
@@ -18,6 +20,7 @@ We now also have full support for small molecules, with the `MoleculeTokenizer`,
 - Parsers can now be told to read arbitrary fields from their respective file formats with the `custom_fields` parameter.
 - The parsing functionality of `SpctrumDataset` and its subclasses have been moved to the `spectra_to_*` functions in the data module.
 - `SpectrumDataset` and its subclasses now return dictionaries of data rather than a tuple of data. This allows us to incorporate arbitrary additional data
+- `SpectrumDataset` and its subclasses are now `lance.torch.data.LanceDataset` subclasses, providing native PyTorch integration.
 
 ### Added
 - Support for small molecules.

--- a/depthcharge/data/analyte_datasets.py
+++ b/depthcharge/data/analyte_datasets.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterable
 
 import torch
-from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.data import TensorDataset
 
 from ..tokenizers import Tokenizer
 
@@ -38,23 +38,3 @@ class AnalyteDataset(TensorDataset):
     def tokens(self) -> torch.Tensor:
         """The peptide sequence tokens."""
         return self.tensors[0]
-
-    def loader(self, *args: tuple, **kwargs: dict) -> DataLoader:
-        """A PyTorch DataLoader for peptides.
-
-        Parameters
-        ----------
-        *args : tuple
-            Arguments passed initialize a torch.utils.data.DataLoader,
-            excluding ``dataset``.
-        **kwargs : dict
-            Keyword arguments passed initialize a torch.utils.data.DataLoader,
-            excluding ``dataset``.
-
-        Returns
-        -------
-        torch.utils.data.DataLoader
-            A DataLoader for the peptide.
-
-        """
-        return DataLoader(self, *args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ select = ["E", "F", "W", "C", "I", "D", "UP", "N", "T20"]
 ignore = ["D213", "ANN101", "D203", "D100", "ANN102", "D401"]
 
 [tool.ruff.lint.per-file-ignores]
-"*tests/*.py" = ["ANN", "N806"]
+"*tests/*.py" = ["ANN", "N806", "C408"]
 "__init__.py" = ["F401", "D104"]
 "depthcharge/encoders/sinusoidal.py" = ["N803"]
 "depthcharge/feedforward.py" = ["N803"]

--- a/tests/unit_tests/test_data/test_loaders.py
+++ b/tests/unit_tests/test_data/test_loaders.py
@@ -68,7 +68,7 @@ def test_analyte_loader():
     charges = torch.tensor([5, 3, 1])
     tokenizer = PeptideTokenizer()
     dset = AnalyteDataset(tokenizer, seqs, charges)
-    loader = dset.loader(batch_size=2)
+    loader = DataLoader(dset, batch_size=2)
 
     batch = next(iter(loader))
     assert len(batch) == 2
@@ -80,7 +80,7 @@ def test_analyte_loader():
 
     args = (torch.tensor([1, 2, 3]), torch.tensor([[1, 1], [2, 2], [3, 3]]))
     dset = AnalyteDataset(tokenizer, seqs, charges, *args)
-    loader = dset.loader(batch_size=2)
+    loader = DataLoader(dset, batch_size=2)
 
     batch = next(iter(loader))
     assert len(batch) == 4

--- a/tests/unit_tests/test_data/test_loaders.py
+++ b/tests/unit_tests/test_data/test_loaders.py
@@ -32,7 +32,7 @@ def test_streaming_spectrum_loader(mgf_small, tmp_path):
     stream_batch = next(iter(loader))
 
     dset = SpectrumDataset(mgf_small, batch_size=2, path=tmp_path / "test")
-    loader = DataLoader(dset, num_workers=1)
+    loader = DataLoader(dset)
     map_batch = next(iter(loader))
     assert_dicts_equal(stream_batch, map_batch)
 
@@ -68,7 +68,7 @@ def test_analyte_loader():
     charges = torch.tensor([5, 3, 1])
     tokenizer = PeptideTokenizer()
     dset = AnalyteDataset(tokenizer, seqs, charges)
-    loader = dset.loader(batch_size=2, num_workers=0)
+    loader = dset.loader(batch_size=2)
 
     batch = next(iter(loader))
     assert len(batch) == 2
@@ -80,7 +80,7 @@ def test_analyte_loader():
 
     args = (torch.tensor([1, 2, 3]), torch.tensor([[1, 1], [2, 2], [3, 3]]))
     dset = AnalyteDataset(tokenizer, seqs, charges, *args)
-    loader = dset.loader(batch_size=2, num_workers=0)
+    loader = dset.loader(batch_size=2)
 
     batch = next(iter(loader))
     assert len(batch) == 4

--- a/tests/unit_tests/test_data/test_loaders.py
+++ b/tests/unit_tests/test_data/test_loaders.py
@@ -1,8 +1,8 @@
 """Test PyTorch DataLoaders."""
 
 import pyarrow as pa
-import pytest
 import torch
+from torch.utils.data import DataLoader
 
 from depthcharge.data import (
     AnalyteDataset,
@@ -17,30 +17,22 @@ from depthcharge.tokenizers import PeptideTokenizer
 
 def test_spectrum_loader(mgf_small, tmp_path):
     """Test a normal spectrum dataset."""
-    dset = SpectrumDataset(mgf_small, tmp_path / "test")
-    loader = dset.loader(batch_size=1, num_workers=0)
+    dset = SpectrumDataset(mgf_small, batch_size=2, path=tmp_path / "test")
+    loader = DataLoader(dset)
     batch = next(iter(loader))
     assert len(batch) == 7
-    assert batch["mz_array"].shape == (1, 13)
+    assert batch["mz_array"].shape == (1, 2, 20)
     assert isinstance(batch["mz_array"], torch.Tensor)
-
-    with pytest.warns(UserWarning):
-        dset.loader(collate_fn=torch.utils.data.default_collate)
 
 
 def test_streaming_spectrum_loader(mgf_small, tmp_path):
     """Test streaming spectra."""
-    streamer = StreamingSpectrumDataset(mgf_small, 2)
-    loader = streamer.loader(batch_size=2, num_workers=0)
+    streamer = StreamingSpectrumDataset(mgf_small, batch_size=2)
+    loader = DataLoader(streamer)
     stream_batch = next(iter(loader))
-    with pytest.warns(UserWarning):
-        streamer.loader(collate_fn=torch.utils.data.default_collate)
 
-    with pytest.warns(UserWarning):
-        streamer.loader(num_workers=2)
-
-    dset = SpectrumDataset(mgf_small, tmp_path / "test")
-    loader = dset.loader(batch_size=2, num_workers=0)
+    dset = SpectrumDataset(mgf_small, batch_size=2, path=tmp_path / "test")
+    loader = DataLoader(dset, num_workers=1)
     map_batch = next(iter(loader))
     assert_dicts_equal(stream_batch, map_batch)
 
@@ -52,20 +44,22 @@ def test_ann_spectrum_loader(mgf_small):
         mgf_small,
         "seq",
         tokenizer,
-        custom_fields=CustomField(
-            "seq", lambda x: x["params"]["seq"], pa.string()
+        batch_size=1,
+        parse_kwargs=dict(
+            custom_fields=CustomField(
+                "seq", lambda x: x["params"]["seq"], pa.string()
+            ),
         ),
     )
-    loader = dset.loader(batch_size=1, num_workers=0)
-
+    loader = DataLoader(dset, num_workers=0)
     batch = next(iter(loader))
     assert len(batch) == 8
-    assert batch["mz_array"].shape == (1, 13)
+    assert batch["mz_array"].shape == (1, 1, 13)
     assert isinstance(batch["mz_array"], torch.Tensor)
-    torch.testing.assert_close(batch["seq"], tokenizer.tokenize(["LESLIEK"]))
-
-    with pytest.warns(UserWarning):
-        dset.loader(collate_fn=torch.utils.data.default_collate)
+    torch.testing.assert_close(
+        batch["seq"][0, ...],
+        tokenizer.tokenize(["LESLIEK"]),
+    )
 
 
 def test_analyte_loader():


### PR DESCRIPTION
This PR simplifies our `SpectrumDataset` and `AnnotateSpectrumDataset` code to use the native Lance PyTorch integration, `lance.torch.data.LanceDataset`. Resolves #45.