### PR TITLE
Reflect `samples` argument in `SpectrumDataset` lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.4.3]
+
+### Changed
+- Length of the `SpectrumDataset` and `AnnotatedSpectrumDataset` now reflect the `samples` parameter of the `lance.pytorch.LanceDataset` parent class.
+
 ## [v0.4.2]
 
 ### Changed

--- a/depthcharge/data/spectrum_datasets.py
+++ b/depthcharge/data/spectrum_datasets.py
@@ -174,7 +174,11 @@ class SpectrumDataset(LanceDataset):
 
     def __len__(self) -> int:
         """The number of batches in the lance dataset."""
-        return math.ceil(self._dataset.count_rows() / self.batch_size)
+        num = self._dataset.count_rows()
+        if self.samples is not None:
+            num = min(self.samples, num)
+
+        return math.ceil(num / self.batch_size)
 
     def __del__(self) -> None:
         """Cleanup the temporary directory."""

--- a/depthcharge/data/spectrum_datasets.py
+++ b/depthcharge/data/spectrum_datasets.py
@@ -175,7 +175,7 @@ class SpectrumDataset(LanceDataset):
     def __len__(self) -> int:
         """The number of batches in the lance dataset."""
         num = self._dataset.count_rows()
-        if self.samples is not None:
+        if self.samples:
             num = min(self.samples, num)
 
         return math.ceil(num / self.batch_size)

--- a/tests/unit_tests/test_data/test_loaders.py
+++ b/tests/unit_tests/test_data/test_loaders.py
@@ -1,6 +1,7 @@
 """Test PyTorch DataLoaders."""
 
 import pyarrow as pa
+import pytest
 import torch
 from torch.utils.data import DataLoader
 
@@ -23,6 +24,21 @@ def test_spectrum_loader(mgf_small, tmp_path):
     assert len(batch) == 7
     assert batch["mz_array"].shape == (1, 2, 20)
     assert isinstance(batch["mz_array"], torch.Tensor)
+
+
+@pytest.mark.parametrize(["samples", "batches"], [(1, 1), (50, 2), (4, 2)])
+def test_spectrum_loader_samples(mgf_small, tmp_path, samples, batches):
+    """Test sampling."""
+    dset = SpectrumDataset(
+        mgf_small,
+        batch_size=1,
+        path=tmp_path / "test",
+        samples=samples,
+    )
+
+    loaded = list(DataLoader(dset))
+    assert len(dset) == batches
+    assert len(loaded) == batches
 
 
 def test_streaming_spectrum_loader(mgf_small, tmp_path):


### PR DESCRIPTION
This PR makes the `SpectrumDataset` class and its children play nice with the `samples` argument of the parent `LanceDataset`.