### PR TITLE
Save full peak file path key under the `peak_file` field of `SpectrumDataset` instead of just the file name.

### DIFF
--- a/depthcharge/data/parsers.py
+++ b/depthcharge/data/parsers.py
@@ -197,7 +197,7 @@ class BaseParser(ABC):
                             parsed = processor(parsed)
 
                     entry = {
-                        "peak_file": self.peak_file.name,
+                        "peak_file": str(self.peak_file.resolve()),
                         "scan_id": str(parsed.scan_id),
                         "ms_level": parsed.ms_level,
                         "precursor_mz": parsed.precursor_mz,

--- a/tests/unit_tests/test_data/test_datasets.py
+++ b/tests/unit_tests/test_data/test_datasets.py
@@ -47,7 +47,7 @@ def test_indexing(tokenizer, mgf_small, tmp_path):
 
     spec = dataset[0]
     assert len(spec) == 7
-    assert spec["peak_file"] == ["small.mgf"]
+    assert spec["peak_file"] == [str(mgf_small.resolve())]
     assert spec["scan_id"] == ["0"]
     assert spec["ms_level"].item() == 2
     assert (spec["precursor_mz"].item() - 416.2448) < 0.001
@@ -123,7 +123,7 @@ def test_load(tokenizer, tmp_path, mgf_small):
     dataset = SpectrumDataset.from_lance(db_path, 1)
     spec = dataset[0]
     assert len(spec) == 8
-    assert spec["peak_file"] == ["small.mgf"]
+    assert spec["peak_file"] == [str(mgf_small.resolve())]
     assert spec["scan_id"] == ["0"]
     assert spec["ms_level"] == 2
     assert (spec["precursor_mz"] - 416.2448) < 0.001

--- a/tests/unit_tests/test_data/test_parsers.py
+++ b/tests/unit_tests/test_data/test_parsers.py
@@ -71,7 +71,7 @@ def test_mgf_and_base(mgf_small):
     )
     expected = pl.DataFrame(
         {
-            "peak_file": [mgf_small.name] * 2,
+            "peak_file": [str(mgf_small.resolve())] * 2,
             "scan_id": ["0", "1"],
             "ms_level": [2, 2],
             "precursor_mz": [416.24474357, 257.464565],


### PR DESCRIPTION
In order to differentiate between peak files that may have the same file name but have different file paths, I made a slight modification to `SpectrumDataset` to save the full (resolved) file path under the `peak_file` key. I also updated the unit test to reflect this new behavior as needed.