### PR TITLE
Added index= prefix for the `scan_id` key for spectra originating from MGF files

### DIFF
--- a/depthcharge/data/parsers.py
+++ b/depthcharge/data/parsers.py
@@ -520,7 +520,7 @@ class MgfParser(BaseParser):
         if self.valid_charge is None or precursor_charge in self.valid_charge:
             return MassSpectrum(
                 filename=str(self.peak_file),
-                scan_id=self._counter,
+                scan_id=f"index={self._counter}",
                 mz=spectrum["m/z array"],
                 intensity=spectrum["intensity array"],
                 ms_level=self._assumed_ms_level,

--- a/tests/unit_tests/test_data/test_datasets.py
+++ b/tests/unit_tests/test_data/test_datasets.py
@@ -48,7 +48,7 @@ def test_indexing(tokenizer, mgf_small, tmp_path):
     spec = dataset[0]
     assert len(spec) == 7
     assert spec["peak_file"] == ["small.mgf"]
-    assert spec["scan_id"] == ["0"]
+    assert spec["scan_id"] == ["index=0"]
     assert spec["ms_level"].item() == 2
     assert (spec["precursor_mz"].item() - 416.2448) < 0.001
 
@@ -124,7 +124,7 @@ def test_load(tokenizer, tmp_path, mgf_small):
     spec = dataset[0]
     assert len(spec) == 8
     assert spec["peak_file"] == ["small.mgf"]
-    assert spec["scan_id"] == ["0"]
+    assert spec["scan_id"] == ["index=0"]
     assert spec["ms_level"] == 2
     assert (spec["precursor_mz"] - 416.2448) < 0.001
 

--- a/tests/unit_tests/test_data/test_parsers.py
+++ b/tests/unit_tests/test_data/test_parsers.py
@@ -72,7 +72,7 @@ def test_mgf_and_base(mgf_small):
     expected = pl.DataFrame(
         {
             "peak_file": [mgf_small.name] * 2,
-            "scan_id": ["0", "1"],
+            "scan_id": ["index=0", "index=1"],
             "ms_level": [2, 2],
             "precursor_mz": [416.24474357, 257.464565],
             "precursor_charge": [2, 3],


### PR DESCRIPTION
I modified `MgfParser` to add the `index=` prefix to the `scan_id` field. I also updated unit test to reflect this new behavior as needed.