### PR TITLE
Adjust lance docs url

### DIFF
--- a/depthcharge/data/spectrum_datasets.py
+++ b/depthcharge/data/spectrum_datasets.py
@@ -32,12 +32,12 @@ class SpectrumDataset(LanceDataset):
     """Store and access a collection of mass spectra.
 
     Parse and/or add mass spectra to an index in the
-    [lance data format](https://lancedb.github.io/lance/index.html).
+    [lance data format](https://lance.org).
     This format enables fast random access to spectra for training.
     This file is then served as a PyTorch IterableDataset, allowing
     spectra to be accessed efficiently for training and inference.
     This is accomplished using the
-    [Lance PyTorch integration](https://lancedb.github.io/lance/integrations/pytorch.html).
+    [Lance PyTorch integration](https://lance.org/integrations/pytorch).
 
     The `batch_size` parameter for this class indepedent of the `batch_size`
     of the PyTorch DataLoader. Generally, we only want the former parameter to
@@ -70,7 +70,7 @@ class SpectrumDataset(LanceDataset):
         DataFrame or parquet file inputs.
     **kwargs : dict
         Keyword arguments to initialize a
-        `[lance.torch.data.LanceDataset](https://lancedb.github.io/lance/api/python/lance.torch.html#lance.torch.data.LanceDataset)`.
+        `[lance.torch.data.LanceDataset](https://github.com/lance-format/lance/blob/92aa361099f42a40e9aa9f9915d041fe1dd30671/python/python/lance/torch/data.py#L177)`.
 
     Attributes
     ----------
@@ -220,7 +220,7 @@ class SpectrumDataset(LanceDataset):
             peak files that are provided.
         **kwargs : dict
             Keyword arguments to initialize a
-            `[lance.torch.data.LanceDataset](https://lancedb.github.io/lance/api/python/lance.torch.html#lance.torch.data.LanceDataset)`.
+            `[lance.torch.data.LanceDataset](https://github.com/lance-format/lance/blob/92aa361099f42a40e9aa9f9915d041fe1dd30671/python/python/lance/torch/data.py#L177)`.
 
         Returns
         -------
@@ -273,12 +273,12 @@ class AnnotatedSpectrumDataset(SpectrumDataset):
     """Store and access a collection of annotated mass spectra.
 
     Parse and/or add mass spectra to an index in the
-    [lance data format](https://lancedb.github.io/lance/index.html).
+    [lance data format](https://lance.org).
     This format enables fast random access to spectra for training.
     This file is then served as a PyTorch IterableDataset, allowing
     spectra to be accessed efficiently for training and inference.
     This is accomplished using the
-    [Lance PyTorch integration](https://lancedb.github.io/lance/integrations/pytorch.html).
+    [Lance PyTorch integration](https://lance.org/integrations/pytorch).
 
     The `batch_size` parameter for this class indepedent of the `batch_size`
     of the PyTorch DataLoader. Generally, we only want the former parameter to
@@ -316,7 +316,7 @@ class AnnotatedSpectrumDataset(SpectrumDataset):
         DataFrame or parquet file inputs.
     **kwargs : dict
         Keyword arguments to initialize a
-        `[lance.torch.data.LanceDataset](https://lancedb.github.io/lance/api/python/lance.torch.html#lance.torch.data.LanceDataset)`.
+        `[lance.torch.data.LanceDataset](https://github.com/lance-format/lance/blob/92aa361099f42a40e9aa9f9915d041fe1dd30671/python/python/lance/torch/data.py#L177)`.
 
     Attributes
     ----------
@@ -410,7 +410,7 @@ class AnnotatedSpectrumDataset(SpectrumDataset):
             peak files that are provided.
         **kwargs : dict
             Keyword arguments to initialize a
-            `[lance.torch.data.LanceDataset](https://lancedb.github.io/lance/api/python/lance.torch.html#lance.torch.data.LanceDataset)`.
+            `[lance.torch.data.LanceDataset](https://github.com/lance-format/lance/blob/92aa361099f42a40e9aa9f9915d041fe1dd30671/python/python/lance/torch/data.py#L177)`.
 
         Returns
         -------

--- a/docs/getting-started/spectra.qmd
+++ b/docs/getting-started/spectra.qmd
@@ -163,7 +163,7 @@ For this task, Depthcharge provides three dataset classes for mass spectra:
 - `AnnotatedSpectrumDataset` - Use this class for training on annotated mass spectra, such as peptide-spectrum matches.
 - `StreamingSpectrumDataset` - Use this class for running inference on mass spectra.
 
-The `SpectrumDataset` and `AnnotatedSpectrumDataset` classes parse spectra into a [Lance dataset](https://lancedb.github.io/lance/index.html#) which allows for efficient on-disk storage and fast random access of the stored spectra.
+The `SpectrumDataset` and `AnnotatedSpectrumDataset` classes parse spectra into a [Lance dataset](https://lance.org) which allows for efficient on-disk storage and fast random access of the stored spectra.
 
 All of these classes can be created from the same mass spectrometry data formats as above, or can be created from previously parsed mass spectra as dataframes or Parquet files.
 Furthermore, when doing the former, all of the same features for preprocessing and adding additional data are available using the `parse_kwargs` parameter.
@@ -177,7 +177,7 @@ parse_kwargs = {"progress": False}
 dataset = SpectrumDataset(mzml_file, batch_size=2, parse_kwargs=parse_kwargs)
 ```
 
-The `SpectrumDataset` and `AnnoatatedSpectrumDataset` use the native [PyTorch integration in Lance](https://lancedb.github.io/lance/integrations/pytorch.html) and all of the corresponding parameters are available as keyword arguments.
+The `SpectrumDataset` and `AnnoatatedSpectrumDataset` use the native [PyTorch integration in Lance](https://lance.org/integrations/pytorch) and all of the corresponding parameters are available as keyword arguments.
 Furthermore, all three of these classes are [PyTorch `IterableDataset` classes](https://pytorch.org/docs/stable/data.html#iterable-style-datasets), so they are ready to be used directly to train and evaulate deep learning models with PyTorch.
 
 **A word of caution:** the batch size and any parallelism a best handled by the dataset class itself rather than the PyTorch `DataLoader`; hence, we recommend initializing `DataLoaders` with `num_workers` <= 1 and `batch_size` = 1, or simply:


### PR DESCRIPTION
Fixes https://github.com/wfondrie/depthcharge/issues/77.

One note: I have hard-coded the link to the documentation of `lance.torch.data.LanceDataset` to redirect to the source code itself, because I could unfortunately not find a Python API docs page referencing this class specifically. It seems to me that the lance documentation is a bit [all](https://lancedb.com/docs/training/torch/) [over](https://lancedb.github.io/lancedb/python/python/) [the](https://lance-format.github.io/lance-python-doc/) [place](https://lance.org/integrations/pytorch/).