### PR TITLE
Add float16 and bfloat16 support in sinusoidal encodings.

### DIFF
--- a/tests/unit_tests/test_encoders/test_sinusoidal.py
+++ b/tests/unit_tests/test_encoders/test_sinusoidal.py
@@ -1,5 +1,7 @@
 """Test the encoders."""
 
+import warnings
+
 import numpy as np
 import pytest
 import torch
@@ -96,3 +98,83 @@ def test_both_sinusoid():
     assert isinstance(enc.int_encoder, FloatEncoder)
     assert isinstance(enc.int_encoder.sin_term, torch.nn.Parameter)
     assert isinstance(enc.mz_encoder.sin_term, torch.nn.Parameter)
+
+
+def test_float_encoder_dtype_conversion():
+    """Test FloatEncoder buffers stay at float32 after dtype conversion."""
+    enc_bf16 = FloatEncoder(8, 0.1, 10).bfloat16()
+    X = torch.tensor([[0.0, 0.1, 10, 0.256]])
+
+    # In the case of static wavelens, sin/cos_term will always be float32
+    assert enc_bf16.sin_term.dtype == torch.float32
+    assert enc_bf16.cos_term.dtype == torch.float32
+    assert enc_bf16._dtype_tracker.dtype == torch.bfloat16
+    Y = enc_bf16(X.bfloat16())
+    assert Y.dtype == torch.bfloat16
+
+
+def test_float_encoder_learnable_dtype_conversion():
+    """Test learnable parameters follow dtype conversion."""
+    enc_bf16 = FloatEncoder(8, 0.1, 10, learnable_wavelengths=True).bfloat16()
+    X = torch.tensor([[0.0, 0.1, 10, 0.256]])
+
+    # In the case of learnable wavelengths, sin/cos_term will be cast
+    assert enc_bf16.sin_term.dtype == torch.bfloat16
+    assert enc_bf16.cos_term.dtype == torch.bfloat16
+    assert enc_bf16._dtype_tracker.dtype == torch.bfloat16
+    Y = enc_bf16(X.bfloat16())
+    assert Y.dtype == torch.bfloat16
+
+
+def test_float_encoder_precision_warning():
+    """Test warning is issued for lower precision inputs."""
+    enc = FloatEncoder(8, 0.1, 10)
+    X = torch.tensor([[0.0, 0.1, 10, 0.256]])
+
+    # Should warn for bfloat16
+    with pytest.warns(UserWarning, match="lower precision than float32"):
+        enc(X.bfloat16())
+
+    # Should warn for float16
+    with pytest.warns(UserWarning, match="lower precision than float32"):
+        enc(X.half())
+
+    # Should not warn for float32
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        enc(X.float())
+
+
+def test_positional_encoder_dtype_mismatch_warning():
+    """Test PositionalEncoder warns on dtype mismatch."""
+    enc_bf16 = PositionalEncoder(8, 1, 8).bfloat16()
+    X = torch.zeros(2, 5, 8)
+
+    assert enc_bf16.sin_term.dtype == torch.float32
+
+    with pytest.warns(UserWarning, match="does not match model dtype"):
+        enc_bf16(X.float())
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        enc_bf16(X.bfloat16())
+
+
+def test_float_encoder_numerical_stability():
+    """Test that internal computation uses float32 for numerical stability."""
+    enc = FloatEncoder(8, 0.001, 10000)
+
+    # Use moderate values to test stability
+    X = torch.tensor([[10.0, 50.0, 100.0]])
+
+    Y_f32 = enc(X.float())
+
+    enc_bf16 = enc.bfloat16()
+    Y_bf16_f32_input = enc_bf16(X.float())
+
+    torch.testing.assert_close(
+        Y_f32,
+        Y_bf16_f32_input.float(),
+        rtol=1e-3,
+        atol=1e-3,
+    )


### PR DESCRIPTION
Currently, the transformers in `depthcharge` should not be trained with float16 or bfloat16 precision, which has become semi-standard in transformer training.
The issue is two-fold: `self.sin_term` and `self.cos_term` have large numbers which cannot be accurately represented with lower precision, distorting the positional encodings (`PositionalEncoder(1024).sin_term.max()` returns `tensor(15915.4941)`), and the mz resolution of MS experiments can not be faithfully represented using bfloat16 and float16 inputs (i.e., `mz_array` inputs to `SpectrumTransformerEncoder`, see https://github.com/wfondrie/depthcharge/issues/76#issuecomment-3645625465).

This PR does the following:
- When `FloatEncoder`'s `learnable_wavelengths=False`, it fixes `self.sin_term` and `self.cos_term` to `float32` precision.
- When `FloatEncoder` is passed lower than `float32` precision values, it raises a warning.
- It introduces a dummy buffer to convert the sinusoidal encodings to the proper model precision _after_ they have been computed.
- A similar procedure is followed for `PositionalEncoder`, where [this line](https://github.com/wfondrie/depthcharge/blob/5a1afb1b1101a38c8ef6c7ea23658d627e2cd0a3/depthcharge/encoders/sinusoidal.py#L209) would otherwise give inaccurate positions for large sequences in combination with bfloat16 model dtypes.
