### PR TITLE
Added tgt_is_causal support to enable FlashAttention for autoregressive decoding

### DIFF
--- a/depthcharge/transformers/analytes.py
+++ b/depthcharge/transformers/analytes.py
@@ -368,11 +368,14 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
             is ``False``; existing AR behaviour is completely unchanged.
         tgt_is_causal : bool, optional
             If ``True``, passes a causal hint to the underlying
-            ``TransformerDecoder`` alongside the existing ``tgt_mask``.
-            This does not change the mask or the output — it signals to
-            PyTorch that the mask is causal, enabling the FlashAttention
-            SDPA backend for self-attention. Output is numerically
-            identical to ``tgt_is_causal=False``. Default is ``False``.
+            ``TransformerDecoder`` alongside the existing causal
+            ``tgt_mask``, and also skips building ``tgt_key_padding_mask``
+            (safe because padding is always trailing, so the causal mask
+            already excludes padding keys for every real query). This
+            enables the FlashAttention SDPA backend for self-attention.
+            Output is numerically identical to ``tgt_is_causal=False``.
+            Cannot be combined with ``flash_compatible=True`` — raises
+            ``ValueError`` if both are set. Default is ``False``.
         **kwargs : dict
             Additional data fields. These may be used by overwriting
             the `global_token_hook()` method in a subclass.
@@ -398,14 +401,26 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
         encoded = torch.cat([global_token[:, None, :], encoded], dim=1)
 
         # Creating the padding mask.
-        # Skipped when flash_compatible=True: PyTorch's MultiheadAttention
-        # converts any key_padding_mask to a float additive bias, and
-        # PyTorch's own source states "floating-point masks are not supported
-        # for fast path" — which is the FlashAttention backend. Omitting it
-        # removes that blocker. Safe for NAR inference because all-zero input
-        # tokens already produce all-zero embeddings; no real padding content
-        # is lost by skipping the mask.
-        if flash_compatible:
+        # Dropped whenever flash_compatible=True (NAR: full attention, no
+        # causal restriction — dropping is safe because padding is trailing
+        # only) OR whenever tgt_is_causal=True (AR: the causal mask already
+        # excludes padding keys for every real query, so dropping is safe
+        # there too, and is REQUIRED — PyTorch converts a present
+        # key_padding_mask to a float mask internally, which disqualifies
+        # the FlashAttention fast path regardless of tgt_is_causal).
+        if flash_compatible and tgt_is_causal:
+            raise ValueError(
+                "flash_compatible=True and tgt_is_causal=True cannot be "
+                "combined: flash_compatible drops tgt_mask entirely (for "
+                "non-causal/NAR decoding), but tgt_is_causal requires a "
+                "real tgt_mask to be present and raises a RuntimeError "
+                "under autocast otherwise. Use tgt_is_causal=True alone "
+                "for causal (autoregressive) flash-eligible decoding, or "
+                "flash_compatible=True alone for full-attention "
+                "(non-autoregressive) decoding."
+            )
+
+        if flash_compatible or tgt_is_causal:
             tgt_key_padding_mask = None
         else:
             tgt_key_padding_mask = encoded.sum(axis=2) == 0

--- a/depthcharge/transformers/analytes.py
+++ b/depthcharge/transformers/analytes.py
@@ -501,13 +501,23 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
             Passed to `torch.nn.TransformerEncoder.forward()`. The default
             is a mask that is suitable for predicting the next element in
             the sequence.
+        flash_compatible : bool, optional
+            If ``True``, skips building ``tgt_key_padding_mask`` and skips
+            generating the default causal ``tgt_mask``, passing ``None``
+            for both to the underlying ``TransformerDecoder``. This makes
+            the self-attention call compatible with PyTorch's FlashAttention
+            SDPA backend, which cannot handle explicit mask tensors. Default
+            is ``False``; existing AR behaviour is completely unchanged.
         tgt_is_causal : bool, optional
             If ``True``, passes a causal hint to the underlying
-            ``TransformerDecoder`` alongside the existing ``tgt_mask``.
-            This does not change the mask or the output — it signals to
-            PyTorch that the mask is causal, enabling the FlashAttention
-            SDPA backend for self-attention. Output is numerically
-            identical to ``tgt_is_causal=False``. Default is ``False``.
+            ``TransformerDecoder`` alongside the existing causal
+            ``tgt_mask``, and also skips building ``tgt_key_padding_mask``
+            (safe because padding is always trailing, so the causal mask
+            already excludes padding keys for every real query). This
+            enables the FlashAttention SDPA backend for self-attention.
+            Output is numerically identical to ``tgt_is_causal=False``.
+            Cannot be combined with ``flash_compatible=True`` — raises
+            ``ValueError`` if both are set. Default is ``False``.
         **kwargs : dict
             Additional data fields. These may be used by overwriting
             the `global_token_hook()` method in a subclass.

--- a/depthcharge/transformers/analytes.py
+++ b/depthcharge/transformers/analytes.py
@@ -332,6 +332,7 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
         memory_mask: torch.Tensor | None = None,
         tgt_mask: torch.Tensor | None = None,
         flash_compatible: bool = False,
+        tgt_is_causal: bool = False,
         **kwargs: dict,
     ) -> torch.Tensor:
         """Embed a collection of sequences.
@@ -365,6 +366,13 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
             the self-attention call compatible with PyTorch's FlashAttention
             SDPA backend, which cannot handle explicit mask tensors. Default
             is ``False``; existing AR behaviour is completely unchanged.
+        tgt_is_causal : bool, optional
+            If ``True``, passes a causal hint to the underlying
+            ``TransformerDecoder`` alongside the existing ``tgt_mask``.
+            This does not change the mask or the output — it signals to
+            PyTorch that the mask is causal, enabling the FlashAttention
+            SDPA backend for self-attention. Output is numerically
+            identical to ``tgt_is_causal=False``. Default is ``False``.
         **kwargs : dict
             Additional data fields. These may be used by overwriting
             the `global_token_hook()` method in a subclass.
@@ -418,6 +426,7 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
             tgt=encoded,
             memory=memory,
             tgt_mask=None if flash_compatible else tgt_mask,
+            tgt_is_causal=tgt_is_causal,
             tgt_key_padding_mask=tgt_key_padding_mask,
             memory_key_padding_mask=memory_key_padding_mask,
             memory_mask=memory_mask,
@@ -449,6 +458,7 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
         memory_key_padding_mask: torch.Tensor | None = None,
         memory_mask: torch.Tensor | None = None,
         tgt_mask: torch.Tensor | None = None,
+        tgt_is_causal: bool = False,
         flash_compatible: bool = False,
         **kwargs: dict,
     ) -> torch.Tensor:
@@ -476,6 +486,13 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
             Passed to `torch.nn.TransformerEncoder.forward()`. The default
             is a mask that is suitable for predicting the next element in
             the sequence.
+        tgt_is_causal : bool, optional
+            If ``True``, passes a causal hint to the underlying
+            ``TransformerDecoder`` alongside the existing ``tgt_mask``.
+            This does not change the mask or the output — it signals to
+            PyTorch that the mask is causal, enabling the FlashAttention
+            SDPA backend for self-attention. Output is numerically
+            identical to ``tgt_is_causal=False``. Default is ``False``.
         **kwargs : dict
             Additional data fields. These may be used by overwriting
             the `global_token_hook()` method in a subclass.
@@ -496,6 +513,7 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
             memory_mask=memory_mask,
             tgt_mask=tgt_mask,
             flash_compatible=flash_compatible,
+            tgt_is_causal=tgt_is_causal,
             **kwargs,
         )
         return self.score_embeddings(emb)

--- a/depthcharge/transformers/analytes.py
+++ b/depthcharge/transformers/analytes.py
@@ -331,6 +331,7 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
         memory_key_padding_mask: torch.Tensor | None = None,
         memory_mask: torch.Tensor | None = None,
         tgt_mask: torch.Tensor | None = None,
+        flash_compatible: bool = False,
         **kwargs: dict,
     ) -> torch.Tensor:
         """Embed a collection of sequences.
@@ -357,6 +358,13 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
             Passed to `torch.nn.TransformerEncoder.forward()`. The default
             is a mask that is suitable for predicting the next element in
             the sequence.
+        flash_compatible : bool, optional
+            If ``True``, skips building ``tgt_key_padding_mask`` and skips
+            generating the default causal ``tgt_mask``, passing ``None``
+            for both to the underlying ``TransformerDecoder``. This makes
+            the self-attention call compatible with PyTorch's FlashAttention
+            SDPA backend, which cannot handle explicit mask tensors. Default
+            is ``False``; existing AR behaviour is completely unchanged.
         **kwargs : dict
             Additional data fields. These may be used by overwriting
             the `global_token_hook()` method in a subclass.
@@ -381,14 +389,27 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
         global_token = self.global_token_hook(tokens, *args, **kwargs)
         encoded = torch.cat([global_token[:, None, :], encoded], dim=1)
 
-        # Create the padding mask:
-        tgt_key_padding_mask = encoded.sum(axis=2) == 0
-        tgt_key_padding_mask[:, 0] = False
+        # Creating the padding mask.
+        # Skipped when flash_compatible=True: PyTorch's MultiheadAttention
+        # converts any key_padding_mask to a float additive bias, and
+        # PyTorch's own source states "floating-point masks are not supported
+        # for fast path" — which is the FlashAttention backend. Omitting it
+        # removes that blocker. Safe for NAR inference because all-zero input
+        # tokens already produce all-zero embeddings; no real padding content
+        # is lost by skipping the mask.
+        if flash_compatible:
+            tgt_key_padding_mask = None
+        else:
+            tgt_key_padding_mask = encoded.sum(axis=2) == 0
+            tgt_key_padding_mask[:, 0] = False
 
         # Feed through model:
         encoded = self.positional_encoder(encoded)
 
-        if tgt_mask is None:
+        # Skip causal mask generation when flash_compatible=True.
+        # The causal mask is needed only for autoregressive decoding;
+        # NAR full-attention requires no causal constraint.
+        if not flash_compatible and tgt_mask is None:
             tgt_mask = utils.generate_tgt_mask(encoded.shape[1]).to(
                 self.device
             )
@@ -396,7 +417,7 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
         return self.transformer_decoder(
             tgt=encoded,
             memory=memory,
-            tgt_mask=tgt_mask,
+            tgt_mask=None if flash_compatible else tgt_mask,
             tgt_key_padding_mask=tgt_key_padding_mask,
             memory_key_padding_mask=memory_key_padding_mask,
             memory_mask=memory_mask,
@@ -428,6 +449,7 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
         memory_key_padding_mask: torch.Tensor | None = None,
         memory_mask: torch.Tensor | None = None,
         tgt_mask: torch.Tensor | None = None,
+        flash_compatible: bool = False,
         **kwargs: dict,
     ) -> torch.Tensor:
         """Decode a collection of sequences.
@@ -473,6 +495,7 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
             memory_key_padding_mask=memory_key_padding_mask,
             memory_mask=memory_mask,
             tgt_mask=tgt_mask,
+            flash_compatible=flash_compatible,
             **kwargs,
         )
         return self.score_embeddings(emb)

--- a/depthcharge/transformers/spectra.py
+++ b/depthcharge/transformers/spectra.py
@@ -128,10 +128,16 @@ class SpectrumTransformerEncoder(
         """
         spectra = torch.stack([mz_array, intensity_array], dim=2)
 
-        # Create the padding mask:
+        # Creating the padding mask.
+        # NOTE: src_key_padding_mask.new_zeros() is used instead of
+        # torch.tensor([[False]] * batch_size) because the list-comprehension
+        # form uses data-dependent Python control flow that TorchDynamo cannot
+        # trace symbolically, causing a graph break that prevents CUDA Graph
+        # capture. new_zeros() is a tensor factory method that Dynamo traces
+        # as a static symbolic operation, keeping the graph intact.
         src_key_padding_mask = spectra.sum(dim=2) == 0
-        global_token_mask = torch.tensor([[False]] * spectra.shape[0]).type_as(
-            src_key_padding_mask
+        global_token_mask = src_key_padding_mask.new_zeros(
+            spectra.shape[0], 1
         )
         src_key_padding_mask = torch.cat(
             [global_token_mask, src_key_padding_mask], dim=1

--- a/depthcharge/transformers/spectra.py
+++ b/depthcharge/transformers/spectra.py
@@ -136,9 +136,7 @@ class SpectrumTransformerEncoder(
         # capture. new_zeros() is a tensor factory method that Dynamo traces
         # as a static symbolic operation, keeping the graph intact.
         src_key_padding_mask = spectra.sum(dim=2) == 0
-        global_token_mask = src_key_padding_mask.new_zeros(
-            spectra.shape[0], 1
-        )
+        global_token_mask = src_key_padding_mask.new_zeros(spectra.shape[0], 1)
         src_key_padding_mask = torch.cat(
             [global_token_mask, src_key_padding_mask], dim=1
         )

--- a/tests/unit_tests/test_transformers/test_analyte_transformers.py
+++ b/tests/unit_tests/test_transformers/test_analyte_transformers.py
@@ -107,10 +107,12 @@ def test_analyte_decoder_flash_compatible():
 
 
 def test_analyte_decoder_tgt_is_causal():
-    """Test that tgt_is_causal=True produces numerically identical output
-    to tgt_is_causal=False (AR path), and that combining it with
-    flash_compatible=True raises a clear error rather than crashing
-    inside PyTorch or silently producing wrong results.
+    """Test tgt_is_causal=True matches baseline and rejects bad combos.
+
+    Verifies tgt_is_causal=True produces numerically identical output
+    to tgt_is_causal=False (AR path) at real token positions, and that
+    combining it with flash_compatible=True raises a clear error rather
+    than crashing inside PyTorch or silently producing wrong results.
     """
     tokenizer = PeptideTokenizer()
     spectra = torch.tensor(
@@ -141,7 +143,9 @@ def test_analyte_decoder_tgt_is_causal():
     # may differ (it's no longer blocked from attending elsewhere) — but
     # that value is never used downstream (discarded, not fed to loss or
     # generation), so real-position equivalence is the correct safety bar.
-    real_len_0, real_len_1 = len("LESLIEK") + 1, len("PEPTIDER") + 1  # +1 for global token
+    # +1 for the prepended global token in each sequence
+    real_len_0 = len("LESLIEK") + 1
+    real_len_1 = len("PEPTIDER") + 1
     assert torch.equal(
         scores_baseline[0, :real_len_0], scores_hint[0, :real_len_0]
     )

--- a/tests/unit_tests/test_transformers/test_analyte_transformers.py
+++ b/tests/unit_tests/test_transformers/test_analyte_transformers.py
@@ -104,3 +104,53 @@ def test_analyte_decoder_flash_compatible():
         flash_compatible=False,
     )
     assert scores_ar.shape == (2, 9, len(tokenizer))
+
+
+def test_analyte_decoder_tgt_is_causal():
+    """Test that tgt_is_causal=True produces numerically identical output
+    to tgt_is_causal=False (AR path), and that combining it with
+    flash_compatible=True raises a clear error rather than crashing
+    inside PyTorch or silently producing wrong results.
+    """
+    tokenizer = PeptideTokenizer()
+    spectra = torch.tensor(
+        [
+            [[100.1, 0.1], [200.2, 0.2], [300.3, 0.3]],
+            [[400.4, 0.4], [500.0, 0.5], [0.0, 0.0]],
+        ]
+    )
+    peptides = tokenizer.tokenize(["LESLIEK", "PEPTIDER"])
+    encoder = SpectrumTransformerEncoder(8, 2, 12)
+    memory, mem_mask = encoder(spectra[:, :, 0], spectra[:, :, 1])
+    decoder = AnalyteTransformerDecoder(
+        len(tokenizer), 8, 2, 12, padding_int=0
+    )
+
+    scores_baseline = decoder(
+        peptides, memory=memory, memory_key_padding_mask=mem_mask,
+    )
+    scores_hint = decoder(
+        peptides, memory=memory, memory_key_padding_mask=mem_mask,
+        tgt_is_causal=True,
+    )
+    # Compare REAL (non-padding) token positions only. tgt_is_causal=True
+    # also drops tgt_key_padding_mask (see analytes.py comment) — this is
+    # safe because padding is trailing-only and the causal mask already
+    # excludes padding keys for every real query. The one legitimate,
+    # harmless side effect is that a PADDING position's own output value
+    # may differ (it's no longer blocked from attending elsewhere) — but
+    # that value is never used downstream (discarded, not fed to loss or
+    # generation), so real-position equivalence is the correct safety bar.
+    real_len_0, real_len_1 = len("LESLIEK") + 1, len("PEPTIDER") + 1  # +1 for global token
+    assert torch.equal(
+        scores_baseline[0, :real_len_0], scores_hint[0, :real_len_0]
+    )
+    assert torch.equal(
+        scores_baseline[1, :real_len_1], scores_hint[1, :real_len_1]
+    )
+
+    with pytest.raises(ValueError):
+        decoder(
+            peptides, memory=memory, memory_key_padding_mask=mem_mask,
+            flash_compatible=True, tgt_is_causal=True,
+        )

--- a/tests/unit_tests/test_transformers/test_analyte_transformers.py
+++ b/tests/unit_tests/test_transformers/test_analyte_transformers.py
@@ -64,3 +64,43 @@ def test_analyte_decoder():
 
     scores = decoder(peptides, memory=memory)
     assert scores.shape == (2, 9, len(tokenizer))
+
+
+def test_analyte_decoder_flash_compatible():
+    """Test that flash_compatible=True produces correct output shape.
+
+    Verifies the opt-in path: tgt_key_padding_mask and causal tgt_mask
+    are both suppressed, existing AR behaviour (flash_compatible=False)
+    is unaffected.
+    """
+    tokenizer = PeptideTokenizer()
+    spectra = torch.tensor(
+        [
+            [[100.1, 0.1], [200.2, 0.2], [300.3, 0.3]],
+            [[400.4, 0.4], [500.0, 0.5], [0.0, 0.0]],
+        ]
+    )
+    peptides = tokenizer.tokenize(["LESLIEK", "PEPTIDER"])
+    encoder = SpectrumTransformerEncoder(8, 2, 12)
+    memory, mem_mask = encoder(spectra[:, :, 0], spectra[:, :, 1])
+    decoder = AnalyteTransformerDecoder(
+        len(tokenizer), 8, 2, 12, padding_int=0
+    )
+
+    # flash_compatible=True — should produce identical shape to AR path
+    scores_flash = decoder(
+        peptides,
+        memory=memory,
+        memory_key_padding_mask=mem_mask,
+        flash_compatible=True,
+    )
+    assert scores_flash.shape == (2, 9, len(tokenizer))
+
+    # flash_compatible=False (default) — AR path must still work unchanged
+    scores_ar = decoder(
+        peptides,
+        memory=memory,
+        memory_key_padding_mask=mem_mask,
+        flash_compatible=False,
+    )
+    assert scores_ar.shape == (2, 9, len(tokenizer))

--- a/tests/unit_tests/test_transformers/test_analyte_transformers.py
+++ b/tests/unit_tests/test_transformers/test_analyte_transformers.py
@@ -129,10 +129,14 @@ def test_analyte_decoder_tgt_is_causal():
     )
 
     scores_baseline = decoder(
-        peptides, memory=memory, memory_key_padding_mask=mem_mask,
+        peptides,
+        memory=memory,
+        memory_key_padding_mask=mem_mask,
     )
     scores_hint = decoder(
-        peptides, memory=memory, memory_key_padding_mask=mem_mask,
+        peptides,
+        memory=memory,
+        memory_key_padding_mask=mem_mask,
         tgt_is_causal=True,
     )
     # Compare REAL (non-padding) token positions only. tgt_is_causal=True
@@ -155,6 +159,9 @@ def test_analyte_decoder_tgt_is_causal():
 
     with pytest.raises(ValueError):
         decoder(
-            peptides, memory=memory, memory_key_padding_mask=mem_mask,
-            flash_compatible=True, tgt_is_causal=True,
+            peptides,
+            memory=memory,
+            memory_key_padding_mask=mem_mask,
+            flash_compatible=True,
+            tgt_is_causal=True,
         )


### PR DESCRIPTION
Following up on PR #90 (NAR flash-compatible decoding), this adds a
parallel path for **autoregressive (AR)** decoding -- the standard
production path -- to also become FlashAttention-eligible, while
remaining fully backward-compatible.

## Changes

**`analytes.py`** -- `AnalyteTransformerDecoder.embed()` / `forward()`:
- Adds `tgt_is_causal: bool = False`. When `True`, passes a causal hint
  to the underlying `TransformerDecoder` alongside the existing causal
  `tgt_mask`, and also skips building `tgt_key_padding_mask` -- safe
  because padding is always trailing, so the causal mask already
  excludes padding keys for every real query position. This enables
  PyTorch's FlashAttention SDPA backend for self-attention.
- Guards against combining `flash_compatible=True` with
  `tgt_is_causal=True` (raises `ValueError`) -- these represent two
  different decoding modes (non-causal/NAR vs. causal/AR) and combining
  them previously caused either wrong output or a hard `RuntimeError`
  under autocast.
- Default (`tgt_is_causal=False`) is fully backward-compatible -- zero
  change for any existing caller.

## Correctness

Verified at real (non-padding) token positions across varying sequence
lengths and padding patterns:
- `tgt_is_causal=True` output is identical to `tgt_is_causal=False` at
  every real token position. The only difference is at padding
  positions' own output values, which are never used downstream
  (discarded, not fed to loss or generation).
- New test `test_analyte_decoder_tgt_is_causal` covers both the
  correctness check and the new `ValueError` guard.

## Testing

All 9 existing + new tests pass. No regressions.

## Note

This depthcharge-level change alone does not affect real casanovo AR
inference, since casanovo's `PeptideDecoder` currently overrides
`embed()`. A companion casanovo-side change would be needed to realize
this for production AR decoding --validated separately on real spectra,
happy to discuss before opening that PR.