### PR TITLE
Added option to replace deamidation mod with canonical AA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Changed C-terminal and N-terminal modification check to include empty modifications 
+- Changed C-terminal and N-terminal modification check to include empty modifications
+- Added the `replace_n_and_q_deamidated_with_d_and_e` option to the `PeptideTokenizer`, which replaces deamidated N and Q residues with D and E residues, because they are indistinguishable by de novo sequencing.
 
 ## [v0.4.9]
 ### Added

--- a/depthcharge/tokenizers/peptides.py
+++ b/depthcharge/tokenizers/peptides.py
@@ -27,6 +27,10 @@ class PeptideTokenizer(Tokenizer):
     replace_isoleucine_with_leucine : bool, optional
         Replace I with L residues, because they are isomeric and often
         indistinguishable by mass spectrometry.
+    replace_n_and_q_deamidated_with_d_and_e : bool, optional
+        Replace deamidated N and Q residues with D and E residues,
+        respectively, because they are indistinguishable
+        by de novo sequencing.
     reverse : bool, optional
         Reverse the sequence for tokenization, C-terminus to N-terminus.
     start_token : str, optional
@@ -39,6 +43,9 @@ class PeptideTokenizer(Tokenizer):
     residues : SortedDict[str, float]
         The residues and modifications and their associated masses.
         terminal modifcations are indicated by `-`.
+    deamidated_to_acid : dict[str, str]
+        The deamidated residues and the residues that replace them when
+        `replace_n_and_q_deamidated_with_d_and_e` is used.
     index : SortedDict{str, int}
         The mapping of residues and modifications to integer representations.
     reverse_index : list[None | str]
@@ -80,6 +87,10 @@ class PeptideTokenizer(Tokenizer):
         "W": 186.079312980,
     }
 
+    # The canonical tokens that depthcharge parses deamidation into,
+    # regardless of how it was originally written, and their replacements:
+    deamidated_to_acid = {"N[Deamidated]": "D", "Q[Deamidated]": "E"}
+
     # The peptide parsing function:
     _parse_peptide = Peptide.from_proforma
 
@@ -87,12 +98,16 @@ class PeptideTokenizer(Tokenizer):
         self,
         residues: Iterable[str] | None = None,
         replace_isoleucine_with_leucine: bool = False,
+        replace_n_and_q_deamidated_with_d_and_e: bool = False,
         reverse: bool = False,
         start_token: str | None = None,
         stop_token: str | None = "$",
     ) -> None:
         """Initialize a PeptideTokenizer."""
         self.replace_isoleucine_with_leucine = replace_isoleucine_with_leucine
+        self.replace_n_and_q_deamidated_with_d_and_e = (
+            replace_n_and_q_deamidated_with_d_and_e
+        )
         self.reverse = reverse
 
         # Note that these also secretly work on dicts too ;)
@@ -103,6 +118,11 @@ class PeptideTokenizer(Tokenizer):
         if self.replace_isoleucine_with_leucine:
             if "I" in self.residues:
                 del self.residues["I"]
+
+        if self.replace_n_and_q_deamidated_with_d_and_e:
+            for token in self.deamidated_to_acid:
+                if token in self.residues:
+                    del self.residues[token]
 
         super().__init__(self.residues, start_token, stop_token)
         self.masses = torch.tensor(
@@ -159,6 +179,9 @@ class PeptideTokenizer(Tokenizer):
             pep.sequence = pep.sequence.replace("I", "L")
 
         pep = pep.split()
+        if self.replace_n_and_q_deamidated_with_d_and_e:
+            pep = [self.deamidated_to_acid.get(t, t) for t in pep]
+
         if self.reverse:
             pep.reverse()
 
@@ -210,6 +233,7 @@ class PeptideTokenizer(Tokenizer):
         cls,
         sequences: Iterable[str],
         replace_isoleucine_with_leucine: bool = False,
+        replace_n_and_q_deamidated_with_d_and_e: bool = False,
         reverse: bool = False,
         start_token: str | None = None,
         stop_token: str | None = "$",
@@ -226,6 +250,10 @@ class PeptideTokenizer(Tokenizer):
         replace_isoleucine_with_leucine : bool, optional
             Replace I with L residues, because they are isobaric and often
             indistinguishable by mass spectrometry.
+        replace_n_and_q_deamidated_with_d_and_e : bool, optional
+            Replace deamidated N and Q residues with D and E residues,
+            respectively, because they are indistinguishable by de novo
+            sequencing.
         reverse : bool, optional
             Reverse the sequence for tokenization, C-terminus to N-terminus.
         start_token : str, optional
@@ -271,6 +299,7 @@ class PeptideTokenizer(Tokenizer):
         return cls(
             new_res,
             replace_isoleucine_with_leucine,
+            replace_n_and_q_deamidated_with_d_and_e,
             reverse,
             start_token,
             stop_token,
@@ -279,6 +308,7 @@ class PeptideTokenizer(Tokenizer):
     @staticmethod
     def from_massivekb(
         replace_isoleucine_with_leucine: bool = False,
+        replace_n_and_q_deamidated_with_d_and_e: bool = False,
         reverse: bool = False,
         start_token: str | None = None,
         stop_token: str | None = "$",
@@ -293,6 +323,10 @@ class PeptideTokenizer(Tokenizer):
         replace_isoleucine_with_leucine : bool, optional
             Replace I with L residues, because they are isobaric and often
             indistinguishable by mass spectrometry.
+        replace_n_and_q_deamidated_with_d_and_e : bool, optional
+            Replace deamidated N and Q residues with D and E residues,
+            respectively, because they are indistinguishable by de novo
+            sequencing.
         reverse : bool, optional
             Reverse the sequence for tokenization, C-terminus to N-terminus.
         start_token : str, optional
@@ -309,6 +343,7 @@ class PeptideTokenizer(Tokenizer):
         return MskbPeptideTokenizer.from_proforma(
             [f"{mod}A" for mod in MSKB_TO_UNIMOD.values()],
             replace_isoleucine_with_leucine,
+            replace_n_and_q_deamidated_with_d_and_e,
             reverse,
             start_token,
             stop_token,
@@ -327,6 +362,10 @@ class MskbPeptideTokenizer(PeptideTokenizer):
     replace_isoleucine_with_leucine : bool
         Replace I with L residues, because they are isobaric and often
         indistinguishable by mass spectrometry.
+    replace_n_and_q_deamidated_with_d_and_e : bool
+        Replace deamidated N and Q residues with D and E residues,
+        respectively, because they are indistinguishable by de novo
+        sequencing.
     reverse : bool
         Reverse the sequence for tokenization, C-terminus to N-terminus.
     start_token : str, optional

--- a/tests/unit_tests/test_tokenizers/test_peptides.py
+++ b/tests/unit_tests/test_tokenizers/test_peptides.py
@@ -80,6 +80,48 @@ def test_mskb_init():
     assert tokens == ["[Acetyl]-", "E", "D", "I", "T", "H"]
 
 
+def test_replace_deamidated():
+    """Test that deamidated N and Q are replaced with D and E."""
+    seqs = ["N[Deamidated]LESLQ[Deamidated]EK"]
+    tokenizer = PeptideTokenizer.from_proforma(
+        sequences=seqs,
+        replace_n_and_q_deamidated_with_d_and_e=True,
+    )
+
+    # The deamidated residues are dropped from the vocabulary:
+    assert "N[Deamidated]" not in tokenizer.residues
+    assert "Q[Deamidated]" not in tokenizer.residues
+
+    tokens = tokenizer.tokenize(seqs, to_strings=True)[0]
+    assert tokens == list("DLESLEEK")
+
+    # Alternative spellings of deamidation are replaced as well:
+    tokens = tokenizer.tokenize(
+        ["N[Deamidation]LESLQ[U:Deamidated]EK"],
+        to_strings=True,
+    )[0]
+    assert tokens == list("DLESLEEK")
+
+    charges = torch.tensor([2])
+    torch.testing.assert_close(
+        tokenizer.calculate_precursor_ions(seqs, charges),
+        tokenizer.calculate_precursor_ions(["DLESLEEK"], charges),
+    )
+
+    # MassIVE-KB annotations are replaced too:
+    mskb = PeptideTokenizer.from_massivekb(
+        replace_n_and_q_deamidated_with_d_and_e=True,
+    )
+    tokens = mskb.tokenize(["EN+0.984DITQ+0.984H"], to_strings=True)[0]
+    assert tokens == list("EDDITEH")
+
+    # Without the option, deamidated residues remain distinct tokens:
+    tokenizer = PeptideTokenizer.from_proforma(sequences=seqs)
+    tokens = tokenizer.tokenize(seqs, to_strings=True)[0]
+    assert tokens[0] == "N[Deamidated]"
+    assert tokens[5] == "Q[Deamidated]"
+
+
 def test_torch_precursor_ions():
     """Test the calculation of the precursor m/z."""
     seqs = ["LESLIEK", "EDITHR"]


### PR DESCRIPTION
Related to [this Casanovo issue](https://github.com/Noble-Lab/casanovo/issues/676). 
Added an option to replace N[Deamidated] with D and Q[Deamidated] with E as they are not distinguishable in de novo sequencing, just like I and L.

