### PR TITLE
Record the full peak file path instead of only the file name

### DIFF
--- a/depthcharge/data/parsers.py
+++ b/depthcharge/data/parsers.py
@@ -199,7 +199,7 @@ class BaseParser(ABC):
                             parsed = processor(parsed)
 
                     entry = {
-                        "peak_file": self.peak_file.name,
+                        "peak_file": str(self.peak_file),
                         "scan_id": str(parsed.scan_id),
                         "ms_level": parsed.ms_level,
                         "precursor_mz": parsed.precursor_mz,

--- a/tests/unit_tests/test_data/test_datasets.py
+++ b/tests/unit_tests/test_data/test_datasets.py
@@ -47,7 +47,7 @@ def test_indexing(tokenizer, mgf_small, tmp_path):
 
     spec = dataset[0]
     assert len(spec) == 7
-    assert spec["peak_file"] == ["small.mgf"]
+    assert spec["peak_file"] == [str(mgf_small)]
     assert spec["scan_id"] == ["index=0"]
     assert spec["ms_level"].item() == 2
     assert (spec["precursor_mz"].item() - 416.2448) < 0.001
@@ -123,7 +123,7 @@ def test_load(tokenizer, tmp_path, mgf_small):
     dataset = SpectrumDataset.from_lance(db_path, 1)
     spec = dataset[0]
     assert len(spec) == 8
-    assert spec["peak_file"] == ["small.mgf"]
+    assert spec["peak_file"] == [str(mgf_small)]
     assert spec["scan_id"] == ["index=0"]
     assert spec["ms_level"] == 2
     assert (spec["precursor_mz"] - 416.2448) < 0.001

--- a/tests/unit_tests/test_data/test_parsers.py
+++ b/tests/unit_tests/test_data/test_parsers.py
@@ -1,5 +1,7 @@
 """Test that parsers work."""
 
+import shutil
+
 import polars as pl
 import pyarrow as pa
 import pytest
@@ -72,7 +74,7 @@ def test_mgf_and_base(mgf_small):
     )
     expected = pl.DataFrame(
         {
-            "peak_file": [mgf_small.name] * 2,
+            "peak_file": [str(mgf_small)] * 2,
             "scan_id": ["index=0", "index=1"],
             "ms_level": [2, 2],
             "precursor_mz": [416.24474357, 257.464565],
@@ -238,3 +240,22 @@ def test_invalid_file(tmp_path):
 
     with pytest.raises(OSError):
         ParserFactory().get_parser(tmp_path / "blah.txt")
+
+
+def test_peak_file_full_path(mgf_small, tmp_path):
+    """peak_file records the full path, not just the base name (#65)."""
+    paths = []
+    for sub in ("a", "b"):
+        path = tmp_path / sub / mgf_small.name
+        path.parent.mkdir()
+        shutil.copy(mgf_small, path)
+        paths.append(path)
+
+    peak_files = [
+        pl.from_arrow(MgfParser(path, preprocessing_fn=[]).iter_batches(None))[
+            "peak_file"
+        ][0]
+        for path in paths
+    ]
+    assert peak_files == [str(paths[0]), str(paths[1])]
+    assert paths[0].name == paths[1].name


### PR DESCRIPTION
Closes #65.

`BaseParser` stored only the file name (`self.peak_file.name`) in the `peak_file` field, so spectra from files that share a name in different directories (e.g. `a/spectra.mgf` and `b/spectra.mgf`) were indistinguishable. The full path (`str(self.peak_file)`) is now stored instead.

Updated the existing tests that asserted the base name, and added a test that parses two same-named files from different directories and checks the recorded paths differ.

Made with the help of AI tools; I have reviewed and take responsibility for all changes.
