### PR TITLE
Added  enable_nested_tensor parameter to SpectrumTransformerEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added the `enable_nested_tensor` parameter to `SpectrumTransformerEncoder`, which allows disabling PyTorch's nested tensor fast path. The fast path forces a host-device synchronization that prevents `torch.compile` from capturing the encoder as a single graph.
 - Changed C-terminal and N-terminal modification check to include empty modifications
 - Added the `replace_n_and_q_deamidated_with_d_and_e` option to the `PeptideTokenizer`, which replaces deamidated N and Q residues with D and E residues, because they are indistinguishable by de novo sequencing.
 

--- a/depthcharge/transformers/spectra.py
+++ b/depthcharge/transformers/spectra.py
@@ -37,6 +37,13 @@ class SpectrumTransformerEncoder(
         The function to encode the (m/z, intensity) tuples of each mass
         spectrum. `True` uses the default sinusoidal encoding and `False`
         instead performs a 1 to `d_model` learned linear projection.
+    enable_nested_tensor : bool, optional
+        Use PyTorch's nested tensor fast path in the Transformer encoder.
+        This is passed to ``torch.nn.TransformerEncoder``. The fast path
+        computes a Python ``bool`` from tensor data, which forces a
+        host-device synchronization and prevents ``torch.compile`` from
+        capturing the encoder as a single graph. Set this to ``False``
+        for compiled or CUDA graph inference on fixed-length inputs.
 
     Attributes
     ----------
@@ -61,6 +68,7 @@ class SpectrumTransformerEncoder(
         n_layers: int = 1,
         dropout: float = 0.0,
         peak_encoder: PeakEncoder | Callable | bool = True,
+        enable_nested_tensor: bool = True,
     ) -> None:
         """Initialize a SpectrumEncoder."""
         super().__init__()
@@ -89,6 +97,7 @@ class SpectrumTransformerEncoder(
         self.transformer_encoder = torch.nn.TransformerEncoder(
             layer,
             num_layers=self.n_layers,
+            enable_nested_tensor=enable_nested_tensor,
         )
 
     def forward(

--- a/tests/unit_tests/test_transformers/test_spectrum_transformers.py
+++ b/tests/unit_tests/test_transformers/test_spectrum_transformers.py
@@ -84,3 +84,25 @@ def test_properties():
     assert model.dim_feedforward == 48
     assert model.n_layers == 3
     assert model.dropout == 0.1
+
+
+def test_enable_nested_tensor(batch):
+    """Test disabling the nested tensor fast path."""
+    model = SpectrumTransformerEncoder(8, 2, 12).eval()
+    dense = SpectrumTransformerEncoder(
+        8, 2, 12, enable_nested_tensor=False
+    ).eval()
+    dense.load_state_dict(model.state_dict())
+
+    assert model.transformer_encoder.enable_nested_tensor
+    assert not dense.transformer_encoder.enable_nested_tensor
+
+    # The fast path is only eligible under inference mode.
+    with torch.no_grad():
+        emb, mask = model(**batch)
+        dense_emb, dense_mask = dense(**batch)
+
+    assert torch.equal(mask, dense_mask)
+    torch.testing.assert_close(
+        dense_emb[~mask], emb[~mask], atol=1e-5, rtol=1e-5
+    )


### PR DESCRIPTION
## Summary

`SpectrumTransformerEncoder` builds `nn.TransformerEncoder` with PyTorch's
default `enable_nested_tensor=True`. That fast path evaluates
`_nested_tensor_from_mask_left_aligned()`, which returns a Python `bool`
computed from tensor data --this breaks `torch.compile` tracing and forces a
host sync that's illegal during `torch.cuda.CUDAGraph` capture.

This PR exposes `enable_nested_tensor` as a pass-through parameter so it can
be disabled for compiled/graph-captured inference. Default is unchanged
(`True`) -- fully backward compatible.

## Results

Measured on Casanovo inference (L4 GPU, BF16, `torch.compile(mode='reduce-overhead')`,
150-peak fixed input, bs=1, 5,000 spectra):

| | before | after |
|---|---|---|
| Encoder graph breaks | 1 | 0 |
| `fullgraph=True` | rejected | accepted |
| Encoder latency | 9.81 ms | **1.24 ms** |
| `cudaLaunchKernel`/spectrum | 403 | 0 |
| **Total pipeline latency (bs=1)** | **13.6 ms** | **4.47 ms (3.05×)** |


## Correctness

Outputs match at all non-padded positions (padded slots differ but are masked
out downstream). Verified on 50 real spectra: mask identical, max diff 2.8e-04
at valid positions, 0/50 predicted-token disagreements.

## Tests

Added `test_enable_nested_tensor`; all existing tests pass unchanged.