### PR TITLE
Fix AnalyteTransformerDecoder error when tokens is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Changed C-terminal and N-terminal modification check to include empty modifications
 - Added the `replace_n_and_q_deamidated_with_d_and_e` option to the `PeptideTokenizer`, which replaces deamidated N and Q residues with D and E residues, because they are indistinguishable by de novo sequencing.
+- Fixed a dtype error in `AnalyteTransformerDecoder.forward` when called with `tokens=None` by initializing the empty token tensor as `int64`.
 
 ## [v0.4.9]
 ### Added

--- a/depthcharge/transformers/analytes.py
+++ b/depthcharge/transformers/analytes.py
@@ -372,7 +372,7 @@ class AnalyteTransformerDecoder(_AnalyteTransformer):
         """
         # Prepare sequences
         if tokens is None:
-            tokens = torch.tensor([[]]).to(self.device)
+            tokens = torch.zeros((1, 0), dtype=torch.int64, device=self.device)
 
         # Encode everything:
         encoded = self.token_encoder(tokens)

--- a/tests/unit_tests/test_transformers/test_analyte_transformers.py
+++ b/tests/unit_tests/test_transformers/test_analyte_transformers.py
@@ -64,3 +64,17 @@ def test_analyte_decoder():
 
     scores = decoder(peptides, memory=memory)
     assert scores.shape == (2, 9, len(tokenizer))
+
+
+def test_analyte_decoder_none_tokens():
+    """A decoder handles ``tokens=None`` (only the global token)."""
+    tokenizer = PeptideTokenizer()
+    n_tokens = len(tokenizer)
+
+    spectra = torch.tensor([[[100.1, 0.1], [200.2, 0.2], [300.3, 0.3]]])
+    encoder = SpectrumTransformerEncoder(8, 2, 12)
+    memory, mem_mask = encoder(spectra[:, :, 0], spectra[:, :, 1])
+
+    decoder = AnalyteTransformerDecoder(n_tokens, 8, 2, 12, padding_int=0)
+    scores = decoder(None, memory=memory, memory_key_padding_mask=mem_mask)
+    assert scores.shape == (1, 1, n_tokens)


### PR DESCRIPTION
Fixes #57.

`AnalyteTransformerDecoder.forward` initialized the empty token tensor with `torch.tensor([[]])`, which defaults to a float dtype. The `token_encoder` embedding expects integer indices, so calling the decoder with `tokens=None` raised an error (as reported in #57).

This initializes the empty tensor as `int64` with the same `(1, 0)` shape, so behavior is otherwise unchanged. Thanks to @andradesalazar for the diagnosis and suggested fix in the issue.

Added a unit test that calls the decoder with `tokens=None` and checks it returns scores for the single global token.